### PR TITLE
Updated kaggle installation steps to fix issue #20

### DIFF
--- a/nb/Kaggle-Qwen2.5_(7B)-Alpaca.ipynb
+++ b/nb/Kaggle-Qwen2.5_(7B)-Alpaca.ipynb
@@ -44,7 +44,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "%%capture\n# Normally using pip install unsloth is enough\n\n# Temporarily as of Jan 31st 2025, Colab has some issues with Pytorch\n# Using pip install unsloth will take 3 minutes, whilst the below takes <1 minute:\n!pip install --no-deps bitsandbytes accelerate xformers==0.0.29.post3 peft trl triton\n!pip install --no-deps cut_cross_entropy unsloth_zoo\n!pip install sentencepiece protobuf datasets huggingface_hub hf_transfer\n!pip install --no-deps unsloth"
+   "source": "%%capture\n!pip uninstall torch torchvision torchaudio -y\n!pip install torch torchvision torchaudio xformers --index-url https://download.pytorch.org/whl/cu121\n!pip install unsloth"
   },
   {
    "cell_type": "markdown",

--- a/nb/Kaggle-Qwen2.5_Coder_(14B)-Conversational.ipynb
+++ b/nb/Kaggle-Qwen2.5_Coder_(14B)-Conversational.ipynb
@@ -44,7 +44,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "%%capture\n# Normally using pip install unsloth is enough\n\n# Temporarily as of Jan 31st 2025, Colab has some issues with Pytorch\n# Using pip install unsloth will take 3 minutes, whilst the below takes <1 minute:\n!pip install --no-deps bitsandbytes accelerate xformers==0.0.29.post3 peft trl triton\n!pip install --no-deps cut_cross_entropy unsloth_zoo\n!pip install sentencepiece protobuf datasets huggingface_hub hf_transfer\n!pip install --no-deps unsloth"
+   "source": "%%capture\n!pip uninstall torch torchvision torchaudio -y\n!pip install torch torchvision torchaudio xformers --index-url https://download.pytorch.org/whl/cu121\n!pip install unsloth"
   },
   {
    "cell_type": "markdown",

--- a/nb/Kaggle-Qwen2_(7B)-Alpaca.ipynb
+++ b/nb/Kaggle-Qwen2_(7B)-Alpaca.ipynb
@@ -44,7 +44,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "%%capture\n# Normally using pip install unsloth is enough\n\n# Temporarily as of Jan 31st 2025, Colab has some issues with Pytorch\n# Using pip install unsloth will take 3 minutes, whilst the below takes <1 minute:\n!pip install --no-deps bitsandbytes accelerate xformers==0.0.29.post3 peft trl triton\n!pip install --no-deps cut_cross_entropy unsloth_zoo\n!pip install sentencepiece protobuf datasets huggingface_hub hf_transfer\n!pip install --no-deps unsloth"
+   "source": "%%capture\n!pip uninstall torch torchvision torchaudio -y\n!pip install torch torchvision torchaudio xformers --index-url https://download.pytorch.org/whl/cu121\n!pip install unsloth"
   },
   {
    "cell_type": "markdown",

--- a/nb/Kaggle-Qwen2_VL_(7B)-Vision.ipynb
+++ b/nb/Kaggle-Qwen2_VL_(7B)-Vision.ipynb
@@ -44,7 +44,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "%%capture\n# Normally using pip install unsloth is enough\n\n# Temporarily as of Jan 31st 2025, Colab has some issues with Pytorch\n# Using pip install unsloth will take 3 minutes, whilst the below takes <1 minute:\n!pip install --no-deps bitsandbytes accelerate xformers==0.0.29.post3 peft trl triton\n!pip install --no-deps cut_cross_entropy unsloth_zoo\n!pip install sentencepiece protobuf datasets huggingface_hub hf_transfer\n!pip install --no-deps unsloth"
+   "source": "%%capture\n!pip uninstall torch torchvision torchaudio -y\n!pip install torch torchvision torchaudio xformers --index-url https://download.pytorch.org/whl/cu121\n!pip install unsloth"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
Fixes a TypeError encountered during `import unsloth` on Kaggle by updating the installation instructions.

The updated installation steps are applied to the following Kaggle notebooks:

- nb/Kaggle-Qwen2.5_(7B)-Alpaca.ipynb
- nb/Kaggle-Qwen2.5_Coder_(14B)-Conversational.ipynb
- nb/Kaggle-Qwen2_(7B)-Alpaca.ipynb
- nb/Kaggle-Qwen2_VL_(7B)-Vision.ipynb

I have verified the fix for these specific notebooks. The changes made should not affect other notebooks, but please review to confirm.