### PR TITLE
Use the transformers 4.51.3 CSM release tag instead of main in the notebook.

### DIFF
--- a/nb/Sesame_CSM_(1B)-TTS.ipynb
+++ b/nb/Sesame_CSM_(1B)-TTS.ipynb
@@ -78,7 +78,7 @@
         "    !pip install --no-deps unsloth\n",
         "\n",
         "# Must install latest transformers for Sesame!\n",
-        "!pip install git+https://github.com/huggingface/transformers.git"
+        "!pip install git+https://github.com/huggingface/transformers@v4.51.3-CSM-preview"
       ]
     },
     {


### PR DESCRIPTION
Transformers has a tag off of their `4.51.3` release [here](https://github.com/huggingface/transformers/releases/tag/v4.51.3-CSM-preview) with the CSM functionality intended to be released in `4.52.0`.

I'm unfamiliar with `transformers` development processes, but the main branch doesn't seem overly stable, so using this tag instead of the main branch might be better.

Feel free to close if I'm off base.