### PR TITLE
Fixing incorrect comment in Qwen Reasoning notebook

### DIFF
--- a/nb/Qwen3_(14B)-Reasoning-Conversational.ipynb
+++ b/nb/Qwen3_(14B)-Reasoning-Conversational.ipynb
@@ -1541,7 +1541,7 @@
     "    messages,\n",
     "    tokenize = False,\n",
     "    add_generation_prompt = True, # Must add for generation\n",
-    "    enable_thinking = True, # Disable thinking\n",
+    "    enable_thinking = True, # Enable thinking\n",
     ")\n",
     "\n",
     "from transformers import TextStreamer\n",


### PR DESCRIPTION
Enable Thinking parameter is True but comment is not updated. Fixing it to avoid confusion.