### PR TITLE
Remove modules_to_save parameter

### DIFF
--- a/nb/Gemma3N_(4B)-Audio.ipynb
+++ b/nb/Gemma3N_(4B)-Audio.ipynb
@@ -8,7 +8,7 @@
     "<div class=\"align-center\">\n",
     "<a href=\"https://unsloth.ai/\"><img src=\"https://github.com/unslothai/unsloth/raw/main/images/unsloth%20new%20logo.png\" width=\"115\"></a>\n",
     "<a href=\"https://discord.gg/unsloth\"><img src=\"https://github.com/unslothai/unsloth/raw/main/images/Discord button.png\" width=\"145\"></a>\n",
-    "<a href=\"https://docs.unsloth.ai/\"><img src=\"https://github.com/unslothai/unsloth/blob/main/images/documentation%20green%20button.png?raw=true\" width=\"125\"></a></a> Join Discord if you need help + \u2b50 <i>Star us on <a href=\"https://github.com/unslothai/unsloth\">Github</a> </i> \u2b50\n",
+    "<a href=\"https://docs.unsloth.ai/\"><img src=\"https://github.com/unslothai/unsloth/blob/main/images/documentation%20green%20button.png?raw=true\" width=\"125\"></a></a> Join Discord if you need help + ⭐ <i>Star us on <a href=\"https://github.com/unslothai/unsloth\">Github</a> </i> ⭐\n",
     "</div>\n",
     "\n",
     "To install Unsloth on your own computer, follow the installation instructions on our Github page [here](https://docs.unsloth.ai/get-started/installing-+-updating).\n",
@@ -51,7 +51,22 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "%%capture\nimport os, re\nif \"COLAB_\" not in \"\".join(os.environ.keys()):\n    !pip install unsloth\nelse:\n    # Do this only in Colab notebooks! Otherwise use pip install unsloth\n    import torch; v = re.match(r\"[0-9\\.]{3,}\", str(torch.__version__)).group(0)\n    xformers = \"xformers==\" + (\"0.0.32.post2\" if v == \"2.8.0\" else \"0.0.29.post3\")\n    !pip install --no-deps bitsandbytes accelerate {xformers} peft trl triton cut_cross_entropy unsloth_zoo\n    !pip install sentencepiece protobuf \"datasets>=3.4.1,<4.0.0\" \"huggingface_hub>=0.34.0\" hf_transfer\n    !pip install --no-deps unsloth\n!pip install transformers==4.55.4\n!pip install --no-deps trl==0.22.2\nimport torch; torch._dynamo.config.recompile_limit = 64;\n"
+   "source": [
+    "%%capture\n",
+    "import os, re\n",
+    "if \"COLAB_\" not in \"\".join(os.environ.keys()):\n",
+    "    !pip install unsloth\n",
+    "else:\n",
+    "    # Do this only in Colab notebooks! Otherwise use pip install unsloth\n",
+    "    import torch; v = re.match(r\"[0-9\\.]{3,}\", str(torch.__version__)).group(0)\n",
+    "    xformers = \"xformers==\" + (\"0.0.32.post2\" if v == \"2.8.0\" else \"0.0.29.post3\")\n",
+    "    !pip install --no-deps bitsandbytes accelerate {xformers} peft trl triton cut_cross_entropy unsloth_zoo\n",
+    "    !pip install sentencepiece protobuf \"datasets>=3.4.1,<4.0.0\" \"huggingface_hub>=0.34.0\" hf_transfer\n",
+    "    !pip install --no-deps unsloth\n",
+    "!pip install transformers==4.55.4\n",
+    "!pip install --no-deps trl==0.22.2\n",
+    "import torch; torch._dynamo.config.recompile_limit = 64;\n"
+   ]
   },
   {
    "cell_type": "code",
@@ -111,8 +126,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\ud83e\udda5 Unsloth: Will patch your computer to enable 2x faster free finetuning.\n",
-      "\ud83e\udda5 Unsloth Zoo will now patch everything to make training faster!\n",
+      "🦥 Unsloth: Will patch your computer to enable 2x faster free finetuning.\n",
+      "🦥 Unsloth Zoo will now patch everything to make training faster!\n",
       "==((====))==  Unsloth 2025.7.5: Fast Gemma3N patching. Transformers: 4.54.0.dev0.\n",
       "   \\\\   /|    Tesla T4. Num GPUs = 1. Max memory: 14.741 GB. Platform: Linux.\n",
       "O^O/ \\_/ \\    Torch: 2.6.0+cu124. CUDA: 7.5. CUDA Toolkit: 12.4. Triton: 3.2.0\n",
@@ -269,7 +284,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " Ich, ich rechne direkt mich an. Das ist nat\u00fcrlich klar, nur, dass, \u00e4h, es politische Interessen gibt im Handel, im Austausch mit Waren, dass es politische Einfl\u00fcsse gibt. Die Frage ist, die Alternative soll es nicht sein.\n"
+      " Ich, ich rechne direkt mich an. Das ist natürlich klar, nur, dass, äh, es politische Interessen gibt im Handel, im Austausch mit Waren, dass es politische Einflüsse gibt. Die Frage ist, die Alternative soll es nicht sein.\n"
      ]
     },
     {
@@ -320,7 +335,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Sie direkt mich an. Das finde ich klar, nur dass es politisch Interessen gibt im Handel, im Austausch mit Waren, dass es politische Einfl\u00fcsse gibt. Die Frage ist, die Alternative soll es nicht sein.<end_of_turn>\n"
+      "Sie direkt mich an. Das finde ich klar, nur dass es politisch Interessen gibt im Handel, im Austausch mit Waren, dass es politische Einflüsse gibt. Die Frage ist, die Alternative soll es nicht sein.<end_of_turn>\n"
      ]
     }
    ],
@@ -425,9 +440,6 @@
     "        # Audio layers\n",
     "        \"post\", \"linear_start\", \"linear_end\",\n",
     "        \"embedding_projection\",\n",
-    "    ],\n",
-    "    modules_to_save=[\n",
-    "        \"embed_audio\",\n",
     "    ],\n",
     ")"
    ]
@@ -1429,7 +1441,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Du sprichst direkt mich an. Das finde ich klar, nur, dass, \u00e4h, dass politische Interessen gibt im Handel, im Austausch mit Waren, dass es politische Einfl\u00fcsse gibt. Die Frage ist, die Alternative soll es nicht sein.<end_of_turn>\n"
+      "Du sprichst direkt mich an. Das finde ich klar, nur, dass, äh, dass politische Interessen gibt im Handel, im Austausch mit Waren, dass es politische Einflüsse gibt. Die Frage ist, die Alternative soll es nicht sein.<end_of_turn>\n"
      ]
     }
    ],
@@ -1671,7 +1683,7 @@
     "  <a href=\"https://discord.gg/unsloth\"><img src=\"https://github.com/unslothai/unsloth/raw/main/images/Discord.png\" width=\"145\"></a>\n",
     "  <a href=\"https://docs.unsloth.ai/\"><img src=\"https://github.com/unslothai/unsloth/blob/main/images/documentation%20green%20button.png?raw=true\" width=\"125\"></a>\n",
     "\n",
-    "  Join Discord if you need help + \u2b50\ufe0f <i>Star us on <a href=\"https://github.com/unslothai/unsloth\">Github</a> </i> \u2b50\ufe0f\n",
+    "  Join Discord if you need help + ⭐️ <i>Star us on <a href=\"https://github.com/unslothai/unsloth\">Github</a> </i> ⭐️\n",
     "</div>\n"
    ]
   }
@@ -1793,9 +1805,9 @@
       "description": "",
       "description_tooltip": null,
       "layout": "IPY_MODEL_dd596d7ce92847178805247ed2ea2902",
-      "placeholder": "\u200b",
+      "placeholder": "​",
       "style": "IPY_MODEL_56256ba8e73c48898b147d2b91f4fd85",
-      "value": "Loading\u2007checkpoint\u2007shards:\u2007100%"
+      "value": "Loading checkpoint shards: 100%"
      }
     },
     "54cedbd8ef984f6a89590f1651804c03": {
@@ -1881,9 +1893,9 @@
       "description": "",
       "description_tooltip": null,
       "layout": "IPY_MODEL_9d544cff64354e6695e90cfd70743d72",
-      "placeholder": "\u200b",
+      "placeholder": "​",
       "style": "IPY_MODEL_3e16f926611b458fbfa21f75bd8de2c2",
-      "value": "Map\u2007(num_proc=4):\u2007100%"
+      "value": "Map (num_proc=4): 100%"
      }
     },
     "6dbca67a4bcf491fa0cdc07f10cca9c2": {
@@ -2352,9 +2364,9 @@
       "description": "",
       "description_tooltip": null,
       "layout": "IPY_MODEL_2d0675287f864fbdac1ca1439bc50077",
-      "placeholder": "\u200b",
+      "placeholder": "​",
       "style": "IPY_MODEL_8ef02bdc9627427d83a6324cb59c445e",
-      "value": "\u20073/3\u2007[00:39&lt;00:00,\u200711.72s/it]"
+      "value": " 3/3 [00:39&lt;00:00, 11.72s/it]"
      }
     },
     "ecbee91d79834a49ab0cb3e33522d8d2": {
@@ -2389,9 +2401,9 @@
       "description": "",
       "description_tooltip": null,
       "layout": "IPY_MODEL_54cedbd8ef984f6a89590f1651804c03",
-      "placeholder": "\u200b",
+      "placeholder": "​",
       "style": "IPY_MODEL_9fdf6d3312be4f51912561ae1cb5a893",
-      "value": "\u20073000/3000\u2007[09:19&lt;00:00,\u2007\u20073.22\u2007examples/s]"
+      "value": " 3000/3000 [09:19&lt;00:00,  3.22 examples/s]"
      }
     },
     "state": {}

--- a/nb/Kaggle-Gemma3N_(4B)-Audio.ipynb
+++ b/nb/Kaggle-Gemma3N_(4B)-Audio.ipynb
@@ -8,7 +8,7 @@
     "<div class=\"align-center\">\n",
     "<a href=\"https://unsloth.ai/\"><img src=\"https://github.com/unslothai/unsloth/raw/main/images/unsloth%20new%20logo.png\" width=\"115\"></a>\n",
     "<a href=\"https://discord.gg/unsloth\"><img src=\"https://github.com/unslothai/unsloth/raw/main/images/Discord button.png\" width=\"145\"></a>\n",
-    "<a href=\"https://docs.unsloth.ai/\"><img src=\"https://github.com/unslothai/unsloth/blob/main/images/documentation%20green%20button.png?raw=true\" width=\"125\"></a></a> Join Discord if you need help + \u2b50 <i>Star us on <a href=\"https://github.com/unslothai/unsloth\">Github</a> </i> \u2b50\n",
+    "<a href=\"https://docs.unsloth.ai/\"><img src=\"https://github.com/unslothai/unsloth/blob/main/images/documentation%20green%20button.png?raw=true\" width=\"125\"></a></a> Join Discord if you need help + ⭐ <i>Star us on <a href=\"https://github.com/unslothai/unsloth\">Github</a> </i> ⭐\n",
     "</div>\n",
     "\n",
     "To install Unsloth on your own computer, follow the installation instructions on our Github page [here](https://docs.unsloth.ai/get-started/installing-+-updating).\n",
@@ -51,7 +51,17 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "%%capture\nimport os\n\n!pip install pip3-autoremove\n!pip install torch torchvision torchaudio xformers --index-url https://download.pytorch.org/whl/cu128\n!pip install unsloth\n!pip install transformers==4.55.4\n!pip install --no-deps trl==0.22.2\nimport torch; torch._dynamo.config.recompile_limit = 64;\n"
+   "source": [
+    "%%capture\n",
+    "import os\n",
+    "\n",
+    "!pip install pip3-autoremove\n",
+    "!pip install torch torchvision torchaudio xformers --index-url https://download.pytorch.org/whl/cu128\n",
+    "!pip install unsloth\n",
+    "!pip install transformers==4.55.4\n",
+    "!pip install --no-deps trl==0.22.2\n",
+    "import torch; torch._dynamo.config.recompile_limit = 64;\n"
+   ]
   },
   {
    "cell_type": "code",
@@ -111,8 +121,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\ud83e\udda5 Unsloth: Will patch your computer to enable 2x faster free finetuning.\n",
-      "\ud83e\udda5 Unsloth Zoo will now patch everything to make training faster!\n",
+      "🦥 Unsloth: Will patch your computer to enable 2x faster free finetuning.\n",
+      "🦥 Unsloth Zoo will now patch everything to make training faster!\n",
       "==((====))==  Unsloth 2025.7.5: Fast Gemma3N patching. Transformers: 4.54.0.dev0.\n",
       "   \\\\   /|    Tesla T4. Num GPUs = 1. Max memory: 14.741 GB. Platform: Linux.\n",
       "O^O/ \\_/ \\    Torch: 2.6.0+cu124. CUDA: 7.5. CUDA Toolkit: 12.4. Triton: 3.2.0\n",
@@ -269,7 +279,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " Ich, ich rechne direkt mich an. Das ist nat\u00fcrlich klar, nur, dass, \u00e4h, es politische Interessen gibt im Handel, im Austausch mit Waren, dass es politische Einfl\u00fcsse gibt. Die Frage ist, die Alternative soll es nicht sein.\n"
+      " Ich, ich rechne direkt mich an. Das ist natürlich klar, nur, dass, äh, es politische Interessen gibt im Handel, im Austausch mit Waren, dass es politische Einflüsse gibt. Die Frage ist, die Alternative soll es nicht sein.\n"
      ]
     },
     {
@@ -320,7 +330,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Sie direkt mich an. Das finde ich klar, nur dass es politisch Interessen gibt im Handel, im Austausch mit Waren, dass es politische Einfl\u00fcsse gibt. Die Frage ist, die Alternative soll es nicht sein.<end_of_turn>\n"
+      "Sie direkt mich an. Das finde ich klar, nur dass es politisch Interessen gibt im Handel, im Austausch mit Waren, dass es politische Einflüsse gibt. Die Frage ist, die Alternative soll es nicht sein.<end_of_turn>\n"
      ]
     }
    ],
@@ -425,9 +435,6 @@
     "        # Audio layers\n",
     "        \"post\", \"linear_start\", \"linear_end\",\n",
     "        \"embedding_projection\",\n",
-    "    ],\n",
-    "    modules_to_save=[\n",
-    "        \"embed_audio\",\n",
     "    ],\n",
     ")"
    ]
@@ -1429,7 +1436,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Du sprichst direkt mich an. Das finde ich klar, nur, dass, \u00e4h, dass politische Interessen gibt im Handel, im Austausch mit Waren, dass es politische Einfl\u00fcsse gibt. Die Frage ist, die Alternative soll es nicht sein.<end_of_turn>\n"
+      "Du sprichst direkt mich an. Das finde ich klar, nur, dass, äh, dass politische Interessen gibt im Handel, im Austausch mit Waren, dass es politische Einflüsse gibt. Die Frage ist, die Alternative soll es nicht sein.<end_of_turn>\n"
      ]
     }
    ],
@@ -1671,7 +1678,7 @@
     "  <a href=\"https://discord.gg/unsloth\"><img src=\"https://github.com/unslothai/unsloth/raw/main/images/Discord.png\" width=\"145\"></a>\n",
     "  <a href=\"https://docs.unsloth.ai/\"><img src=\"https://github.com/unslothai/unsloth/blob/main/images/documentation%20green%20button.png?raw=true\" width=\"125\"></a>\n",
     "\n",
-    "  Join Discord if you need help + \u2b50\ufe0f <i>Star us on <a href=\"https://github.com/unslothai/unsloth\">Github</a> </i> \u2b50\ufe0f\n",
+    "  Join Discord if you need help + ⭐️ <i>Star us on <a href=\"https://github.com/unslothai/unsloth\">Github</a> </i> ⭐️\n",
     "</div>\n"
    ]
   }
@@ -1793,9 +1800,9 @@
       "description": "",
       "description_tooltip": null,
       "layout": "IPY_MODEL_dd596d7ce92847178805247ed2ea2902",
-      "placeholder": "\u200b",
+      "placeholder": "​",
       "style": "IPY_MODEL_56256ba8e73c48898b147d2b91f4fd85",
-      "value": "Loading\u2007checkpoint\u2007shards:\u2007100%"
+      "value": "Loading checkpoint shards: 100%"
      }
     },
     "54cedbd8ef984f6a89590f1651804c03": {
@@ -1881,9 +1888,9 @@
       "description": "",
       "description_tooltip": null,
       "layout": "IPY_MODEL_9d544cff64354e6695e90cfd70743d72",
-      "placeholder": "\u200b",
+      "placeholder": "​",
       "style": "IPY_MODEL_3e16f926611b458fbfa21f75bd8de2c2",
-      "value": "Map\u2007(num_proc=4):\u2007100%"
+      "value": "Map (num_proc=4): 100%"
      }
     },
     "6dbca67a4bcf491fa0cdc07f10cca9c2": {
@@ -2352,9 +2359,9 @@
       "description": "",
       "description_tooltip": null,
       "layout": "IPY_MODEL_2d0675287f864fbdac1ca1439bc50077",
-      "placeholder": "\u200b",
+      "placeholder": "​",
       "style": "IPY_MODEL_8ef02bdc9627427d83a6324cb59c445e",
-      "value": "\u20073/3\u2007[00:39&lt;00:00,\u200711.72s/it]"
+      "value": " 3/3 [00:39&lt;00:00, 11.72s/it]"
      }
     },
     "ecbee91d79834a49ab0cb3e33522d8d2": {
@@ -2389,9 +2396,9 @@
       "description": "",
       "description_tooltip": null,
       "layout": "IPY_MODEL_54cedbd8ef984f6a89590f1651804c03",
-      "placeholder": "\u200b",
+      "placeholder": "​",
       "style": "IPY_MODEL_9fdf6d3312be4f51912561ae1cb5a893",
-      "value": "\u20073000/3000\u2007[09:19&lt;00:00,\u2007\u20073.22\u2007examples/s]"
+      "value": " 3000/3000 [09:19&lt;00:00,  3.22 examples/s]"
      }
     },
     "state": {}

--- a/original_template/Gemma3N_(4B)-Audio.ipynb
+++ b/original_template/Gemma3N_(4B)-Audio.ipynb
@@ -403,9 +403,6 @@
     "        \"post\", \"linear_start\", \"linear_end\",\n",
     "        \"embedding_projection\",\n",
     "    ],\n",
-    "    modules_to_save=[\n",
-    "        \"embed_audio\",\n",
-    "    ],\n",
     ")"
    ]
   },

--- a/python_scripts/Gemma3N_(4B)-Audio.py
+++ b/python_scripts/Gemma3N_(4B)-Audio.py
@@ -185,9 +185,6 @@ model = FastModel.get_peft_model(
         "post", "linear_start", "linear_end",
         "embedding_projection",
     ],
-    modules_to_save=[
-        "embed_audio",
-    ],
 )
 
 

--- a/python_scripts/Kaggle-Gemma3N_(4B)-Audio.py
+++ b/python_scripts/Kaggle-Gemma3N_(4B)-Audio.py
@@ -185,9 +185,6 @@ model = FastModel.get_peft_model(
         "post", "linear_start", "linear_end",
         "embedding_projection",
     ],
-    modules_to_save=[
-        "embed_audio",
-    ],
 )
 
 


### PR DESCRIPTION
The `embed_audio` element in the `modules_to_save` is still causing the `TypeError: AuxiliaryTrainingWrapper.forward() missing 1 required positional argument: 'x'` to be thrown. Fine tuning appears to resolve the issue with commensurate loss/step outputs and values to the original notebook. 