### PR TITLE
Add Gemma phone deployment notebook

### DIFF
--- a/nb/Gemma3_(270M)_Phone_Deployment.ipynb
+++ b/nb/Gemma3_(270M)_Phone_Deployment.ipynb
@@ -74,8 +74,8 @@
         "    !pip install sentencepiece protobuf \"datasets==4.3.0\" \"huggingface_hub>=0.34.0\" hf_transfer\n",
         "    !pip install --no-deps unsloth\n",
         "!pip install transformers==4.56.2\n",
-        "!pip install --no-deps trl==0.22.2\n",
-        "!pip install torchao==0.14.0 executorch pytorch_tokenizers optimum-executorch"
+        "!pip install --no-deps trl==0.25.1\n",
+        "!pip install torchao==0.15.0"
       ]
     },
     {
@@ -138,7 +138,7 @@
         "    dtype = None,\n",
         "    load_in_4bit = False,\n",
         "    full_finetuning = True,\n",
-        "    qat_scheme = \"phone-deployment\", # Flag for phone deployment\n",
+        "    qat_scheme = \"int4\", # Gemma3 needs int4 due to large vocab (262K)\n",
         ")"
       ]
     },
@@ -693,6 +693,31 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Install ExecuTorch Export Dependencies\n",
+        "\n",
+        "The export requires executorch and optimum-executorch. We install executorch with `--no-deps` to avoid replacing your existing CUDA torch (executorch is CPU-only, designed for mobile deployment)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "%%capture\n",
+        "# Install ExecuTorch export dependencies\n",
+        "!pip install expecttest flatbuffers ruamel.yaml tabulate pandas pillow coremltools\n",
+        "!pip install --no-deps executorch --index-url https://download.pytorch.org/whl/nightly/cpu\n",
+        "\n",
+        "# Install optimum-executorch from source\n",
+        "!pip install optimum pytorch-tokenizers\n",
+        "!pip install git+https://github.com/huggingface/optimum-executorch.git --no-deps"
+      ]
+    },
+    {
+      "cell_type": "markdown",
       "metadata": {
         "id": "CrSvZObor0lY"
       },
@@ -703,60 +728,35 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "V--DeL4DMD5O",
-        "outputId": "f5f03485-5c91-45aa-f961-12251a27587d"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "2025-12-18 07:11:27.948447: E external/local_xla/xla/stream_executor/cuda/cuda_fft.cc:467] Unable to register cuFFT factory: Attempting to register factory for plugin cuFFT when one has already been registered\n",
-            "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
-            "E0000 00:00:1766041888.463719    8746 cuda_dnn.cc:8579] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered\n",
-            "E0000 00:00:1766041888.594349    8746 cuda_blas.cc:1407] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered\n",
-            "W0000 00:00:1766041889.547001    8746 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
-            "W0000 00:00:1766041889.547052    8746 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
-            "W0000 00:00:1766041889.547060    8746 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
-            "W0000 00:00:1766041889.547067    8746 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
-            "Skipping import of cpp extensions due to incompatible torch version 2.9.0+cu126 for torchao version 0.14.0         Please see GitHub issue #2919 for more info\n",
-            "`torch_dtype` is deprecated! Use `dtype` instead!\n",
-            "WARNING:coremltools:scikit-learn version 1.7.1 is not supported. Minimum required version: 0.17. Maximum required version: 1.5.1. Disabling scikit-learn conversion API.\n",
-            "WARNING:coremltools:XGBoost version 3.1.2 has not been tested with coremltools. You may run into unexpected errors. XGBoost 1.4.2 is the most recent version that has been tested.\n",
-            "WARNING:coremltools:TensorFlow version 2.19.0 has not been tested with coremltools. You may run into unexpected errors. TensorFlow 2.12.0 is the most recent version that has been tested.\n",
-            "WARNING:coremltools:Torch version 2.9.0+cu126 has not been tested with coremltools. You may run into unexpected errors. Torch 2.7.0 is the most recent version that has been tested.\n",
-            "WARNING:coremltools:Failed to load _MLModelProxy: No module named 'coremltools.libcoremlpython'\n",
-            "WARNING:coremltools:Failed to load _MLCPUComputeDeviceProxy: No module named 'coremltools.libcoremlpython'\n",
-            "WARNING:coremltools:Failed to load _MLGPUComputeDeviceProxy: No module named 'coremltools.libcoremlpython'\n",
-            "WARNING:coremltools:Failed to load _MLNeuralEngineComputeDeviceProxy: No module named 'coremltools.libcoremlpython'\n",
-            "WARNING:coremltools:Failed to load _MLModelProxy: No module named 'coremltools.libcoremlpython'\n",
-            "WARNING:coremltools:Failed to load _MLComputePlanProxy: No module named 'coremltools.libcoremlpython'\n",
-            "WARNING:coremltools:Failed to load _MLModelProxy: No module named 'coremltools.libcoremlpython'\n",
-            "WARNING:coremltools:Failed to load _MLModelAssetProxy: No module named 'coremltools.libcoremlpython'\n",
-            "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/output_graph.py:1711: UserWarning: While exporting, we found certain side effects happened in the model.forward. Here are the list of potential sources you can double check: [\"L['self'].cache.layers[0]\", \"L['self'].cache.layers[1]\", \"L['self'].cache.layers[2]\", \"L['self'].cache.layers[3]\", \"L['self'].cache.layers[4]\", \"L['self'].cache.layers[6]\", \"L['self'].cache.layers[7]\", \"L['self'].cache.layers[8]\", \"L['self'].cache.layers[9]\", \"L['self'].cache.layers[10]\", \"L['self'].cache.layers[12]\", \"L['self'].cache.layers[13]\", \"L['self'].cache.layers[14]\", \"L['self'].cache.layers[15]\", \"L['self'].cache.layers[16]\"]\n",
-            "  warnings.warn(\n",
-            "I tokenizers:regex.cpp:27] Registering override fallback regex\n",
-            "/usr/local/lib/python3.12/dist-packages/executorch/exir/emit/_emitter.py:1594: UserWarning: Mutation on a buffer in the model is detected. ExecuTorch assumes buffers that are mutated in the graph have a meaningless initial state, only the shape and dtype will be serialized, unless a pass which sets meta[\"et_init_buffer\"] to True such as InitializedMutableBufferPass is run.\n",
-            "  warnings.warn(\n"
-          ]
-        }
-      ],
+      "metadata": {},
+      "outputs": [],
       "source": [
-        "# Export directly from your local folder using Optimum\n",
-        "# We use --qlinear 8da4w and --qembedding 8w to reduce size\n",
-        "# 8da4w = Int8 dynamic activations + Int4 weights (Fastest on mobile)\n",
+        "from optimum.executorch import ExecuTorchModelForCausalLM\n",
+        "import shutil\n",
+        "import os\n",
         "\n",
-        "!optimum-cli export executorch \\\n",
-        "    --model \"gemma_phone_model\" \\\n",
-        "    --task \"text-generation\" \\\n",
-        "    --recipe \"xnnpack\" \\\n",
-        "    --output_dir \"gemma_output\" \\\n",
-        "    --qlinear 8da4w \\\n",
-        "    --qembedding 8w"
+        "print(\"Exporting Gemma3-270M to ExecuTorch format...\")\n",
+        "\n",
+        "# Export the trained model using Python API\n",
+        "et_model = ExecuTorchModelForCausalLM.from_pretrained(\n",
+        "    \"gemma_phone_model\",\n",
+        "    export=True,\n",
+        "    recipe=\"xnnpack\",\n",
+        "    task=\"text-generation\",\n",
+        ")\n",
+        "\n",
+        "# Copy .pte file to output directory\n",
+        "temp_dir = et_model._temp_dir.name\n",
+        "os.makedirs(\"gemma_output\", exist_ok=True)\n",
+        "\n",
+        "for f in os.listdir(temp_dir):\n",
+        "    src = os.path.join(temp_dir, f)\n",
+        "    dst = os.path.join(\"gemma_output\", f)\n",
+        "    shutil.copy2(src, dst)\n",
+        "    size_mb = os.path.getsize(dst) / 1024 / 1024\n",
+        "    print(f\"Exported: {f} ({size_mb:.2f} MB)\")\n",
+        "\n",
+        "print(\"\\nExport complete!\")"
       ]
     },
     {
@@ -777,6 +777,31 @@
       "outputs": [],
       "source": [
         "!ls -lh gemma_output/model.pte"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Test Inference on Exported Model"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from transformers import AutoTokenizer\n",
+        "\n",
+        "# Load the exported model for inference\n",
+        "et_model = ExecuTorchModelForCausalLM.from_pretrained(\"gemma_output\", export=False)\n",
+        "tokenizer = AutoTokenizer.from_pretrained(\"gemma_phone_model\")\n",
+        "\n",
+        "# Test generation\n",
+        "prompt = \"<start_of_turn>user\\nWhat is 2 + 2?<end_of_turn>\\n<start_of_turn>model\\n\"\n",
+        "output = et_model.text_generation(tokenizer, prompt, max_seq_len=50)\n",
+        "print(f\"Generated: {output}\")"
       ]
     },
     {


### PR DESCRIPTION
Hey @unslothai, I updated the notebook to use Gemma3 for phone deployment. A main difference in model export is using Optimum (https://github.com/huggingface/optimum-executorch/blob/main/optimum/exporters/executorch/README.md.) Unfortunately I wasn't able to reduce the loss below 17, so I cut the training short. 