### PR TITLE
Fix huggingface_hub compatibility in Gemma3 phone deployment notebook

### DIFF
--- a/nb/Gemma3_(270M)_Phone_Deployment.ipynb
+++ b/nb/Gemma3_(270M)_Phone_Deployment.ipynb
@@ -713,7 +713,12 @@
         "\n",
         "# Install optimum-executorch from source\n",
         "!pip install optimum pytorch-tokenizers\n",
-        "!pip install git+https://github.com/huggingface/optimum-executorch.git --no-deps"
+        "!pip install git+https://github.com/huggingface/optimum-executorch.git --no-deps\n",
+        "\n",
+        "# Fix huggingface_hub compatibility (is_offline_mode was removed)\n",
+        "import huggingface_hub\n",
+        "if not hasattr(huggingface_hub, 'is_offline_mode'):\n",
+        "    huggingface_hub.is_offline_mode = lambda: huggingface_hub.constants.HF_HUB_OFFLINE"
       ]
     },
     {
@@ -1881,7 +1886,7 @@
             "width": null
           }
         },
-        "state" : {}
+        "state": {}
       }
     }
   },


### PR DESCRIPTION
## Summary

The `is_offline_mode` function was removed in newer versions of `huggingface_hub`, causing an ImportError when using optimum-executorch.

This fix adds a compatibility shim that patches `huggingface_hub.is_offline_mode` if it doesn't exist.

## Error Fixed

```
ImportError: cannot import name 'is_offline_mode' from 'huggingface_hub'
```

## Changes

Added to the export dependencies cell:
```python
import huggingface_hub
if not hasattr(huggingface_hub, 'is_offline_mode'):
    huggingface_hub.is_offline_mode = lambda: huggingface_hub.constants.HF_HUB_OFFLINE
```