### PR TITLE
Use stable executorch 1.0.0 and optimum-executorch v0.1.0

### DIFF
--- a/nb/Gemma3_(270M)_Phone_Deployment.ipynb
+++ b/nb/Gemma3_(270M)_Phone_Deployment.ipynb
@@ -707,13 +707,10 @@
       "outputs": [],
       "source": [
         "%%capture\n",
-        "# Install ExecuTorch export dependencies\n",
-        "!pip install expecttest flatbuffers ruamel.yaml tabulate pandas pillow coremltools\n",
-        "!pip install --no-deps executorch --index-url https://download.pytorch.org/whl/nightly/cpu\n",
-        "\n",
-        "# Install optimum-executorch from source\n",
-        "!pip install optimum pytorch-tokenizers\n",
-        "!pip install git+https://github.com/huggingface/optimum-executorch.git --no-deps"
+        "# Install ExecuTorch export dependencies (stable release)\n",
+        "!pip install optimum==1.24.0 pytorch-tokenizers\n",
+        "!pip install executorch==1.0.0+cpu --extra-index-url https://download.pytorch.org/whl/executorch --no-deps\n",
+        "!pip install git+https://github.com/huggingface/optimum-executorch.git@v0.1.0 --no-deps"
       ]
     },
     {
@@ -1881,7 +1878,7 @@
             "width": null
           }
         },
-        "state" : {}
+        "state": {}
       }
     }
   },


### PR DESCRIPTION
## Summary

Switch from nightly executorch to stable releases for better compatibility with Colab's torch version.

## Changes

- Use `executorch==1.0.0+cpu` from PyTorch wheel index (stable)
- Use `optimum-executorch@v0.1.0` (stable tag)
- Use `optimum==1.24.0` (matching requirement)

## Why

The nightly executorch builds are compiled against nightly torch (2.10+), causing ABI mismatch errors with Colab's stable torch 2.9.0:

```
ImportError: undefined symbol: _ZNK3c1010TensorImpl15decref_pyobjectEv
```

Using stable releases should resolve this compatibility issue.