### PR TITLE
Update Dockerfile_DGX_Spark

### DIFF
--- a/Dockerfile_DGX_Spark
+++ b/Dockerfile_DGX_Spark
@@ -17,7 +17,7 @@ RUN git clone https://github.com/triton-lang/triton.git && \
     cd ..
 
 # Install xformers from source for blackwell support
-RUN git clone --depth=1 https://github.com/facebookresearch/xformers --recursive && \
+RUN git clone -b v0.0.33 --depth=1 https://github.com/facebookresearch/xformers --recursive && \
     cd xformers && \
     export TORCH_CUDA_ARCH_LIST="12.1" && \
     python setup.py install && \


### PR DESCRIPTION
Fix build failure by cloning xFormers v0.0.33 instead of main

Cloning the main branch causes a build failure due to a PyTorch version mismatch: xFormers on main requires PyTorch 2.10+, but the current environment uses PyTorch 2.10.0a0.

To resolve this issue, clone and build xFormers from v0.0.33, which is compatible with the existing PyTorch version.