### PR TITLE
Revert to local OpenSpiel server for 2048 RL notebooks

### DIFF
--- a/nb/OpenEnv_gpt_oss_(20B)_Reinforcement_Learning_2048_Game.ipynb
+++ b/nb/OpenEnv_gpt_oss_(20B)_Reinforcement_Learning_2048_Game.ipynb
@@ -99,7 +99,7 @@
       "outputs": [],
       "source": [
         "%%capture\n",
-        "!pip install -qqq git+https://huggingface.co/spaces/openenv/openspiel_env"
+        "!pip install -qqq git+https://github.com/meta-pytorch/OpenEnv.git#subdirectory=envs/openspiel_env"
       ]
     },
     {


### PR DESCRIPTION
## Summary

Fix the 4-bit notebook to use the same OpenSpiel install source as the BF16 notebook.

## Change

```diff
- !pip install -qqq git+https://huggingface.co/spaces/openenv/openspiel_env
+ !pip install -qqq git+https://github.com/meta-pytorch/OpenEnv.git#subdirectory=envs/openspiel_env
```

The HF Space package was broken. The GitHub repo works correctly, and Unsloth auto-starts a local server for the environment.