### PR TITLE
Fix Ministral VL installation cells

### DIFF
--- a/nb/Kaggle-Ministral_3_VL_(3B)_Vision.ipynb
+++ b/nb/Kaggle-Ministral_3_VL_(3B)_Vision.ipynb
@@ -53,7 +53,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "%%capture\nimport os\n\n!pip install pip3-autoremove\n!pip install torch torchvision torchaudio xformers --index-url https://download.pytorch.org/whl/cu128\n!pip install unsloth\n!pip install transformers==4.56.2\n!pip install --no-deps trl==0.22.2"
+   "source": "%%capture\nimport os\n\n!pip install pip3-autoremove\n!pip install torch torchvision torchaudio xformers --index-url https://download.pytorch.org/whl/cu128\n!pip install unsloth\n# Install transformers branch for Ministral\n!pip install git+https://github.com/huggingface/transformers.git@bf3f0ae70d0e902efab4b8517fce88f6697636ce\n!pip install --no-deps trl==0.22.2"
   },
   {
    "cell_type": "markdown",

--- a/nb/Ministral_3_VL_(3B)_Vision.ipynb
+++ b/nb/Ministral_3_VL_(3B)_Vision.ipynb
@@ -72,22 +72,7 @@
         "id": "PglJeZZoOWGG"
       },
       "outputs": [],
-      "source": [
-        "%%capture\n",
-        "import os, re\n",
-        "if \"COLAB_\" not in \"\".join(os.environ.keys()):\n",
-        "    !pip install unsloth\n",
-        "else:\n",
-        "    # Do this only in Colab notebooks! Otherwise use pip install unsloth\n",
-        "    import torch; v = re.match(r\"[0-9]{1,}\\.[0-9]{1,}\", str(torch.__version__)).group(0)\n",
-        "    xformers = \"xformers==\" + (\"0.0.33.post1\" if v==\"2.9\" else \"0.0.32.post2\" if v==\"2.8\" else \"0.0.29.post3\")\n",
-        "    !pip install --no-deps bitsandbytes accelerate {xformers} peft trl triton cut_cross_entropy unsloth_zoo\n",
-        "    !pip install sentencepiece protobuf \"datasets==4.3.0\" \"huggingface_hub>=0.34.0\" hf_transfer\n",
-        "    !pip install --no-deps unsloth\n",
-        "# Install transformers branch for Ministral\n",
-        "!pip install git+https://github.com/huggingface/transformers.git@bf3f0ae70d0e902efab4b8517fce88f6697636ce\n",
-        "!pip install --no-deps trl==0.22.2"
-      ]
+      "source": "%%capture\nimport os, re\nif \"COLAB_\" not in \"\".join(os.environ.keys()):\n    !pip install unsloth\nelse:\n    # Do this only in Colab notebooks! Otherwise use pip install unsloth\n    import torch; v = re.match(r'[\\d]{1,}\\.[\\d]{1,}', str(torch.__version__)).group(0)\n    xformers = 'xformers==' + {'2.10':'0.0.34','2.9':'0.0.33.post1','2.8':'0.0.32.post2'}.get(v, '0.0.34')\n    !pip install sentencepiece protobuf \"datasets==4.3.0\" \"huggingface_hub>=0.34.0\" hf_transfer\n    !pip install --no-deps unsloth_zoo bitsandbytes accelerate {xformers} peft trl triton unsloth\n# Install transformers branch for Ministral\n!pip install git+https://github.com/huggingface/transformers.git@bf3f0ae70d0e902efab4b8517fce88f6697636ce\n!pip install --no-deps trl==0.22.2"
     },
     {
       "cell_type": "markdown",


### PR DESCRIPTION
## Summary
- Add torch 2.10 xformers support (0.0.34)
- Use dictionary mapping for xformers versions
- Remove `cut_cross_entropy` from Colab install
- Keep Ministral-specific transformers git branch

## Files Changed
- `nb/Ministral_3_VL_(3B)_Vision.ipynb`
- `nb/Kaggle-Ministral_3_VL_(3B)_Vision.ipynb`

## Test plan
- [ ] Verify Colab notebook runs with torch 2.10
- [ ] Verify Kaggle notebook runs correctly