### PR TITLE
Refactor update_all_notebooks.py: reorder sections, CRLF handling, README categories

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+* text=auto eol=lf
+*.ipynb text eol=lf
+*.py text eol=lf
+*.md text eol=lf
+*.json text eol=lf
+*.png binary
+*.jpg binary
+*.gif binary
+*.svg binary

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ Below are our notebooks for Google Colab categorized by model. You can view our 
 | **Orpheus-TTS**      | TTS  | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Orpheus_%283B%29-TTS.ipynb)    |
 | **Spark-TTS**        | TTS  | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Spark_TTS_%280_5B%29.ipynb)    |
 | **Oute-TTS**         | TTS  | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Oute_TTS_%281B%29.ipynb)       |
-| **Oute-TTS**         | TTS  | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Oute_TTS_%281B%29.ipynb)       |
 | **Llasa TTS (1B)**   | TTS  | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Llasa_TTS_%281B%29.ipynb)      |
 | **Llasa TTS (3B)**   | TTS  | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Llasa_TTS_%283B%29.ipynb)      |
 | **Whisper-Large-V3** | STT  | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Whisper.ipynb)                 |
@@ -106,6 +105,28 @@ Below are our notebooks for Google Colab categorized by model. You can view our 
 | **Deepseek OCR** **(3B)** | Eval | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Deepseek_OCR_(3B)-Eval.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
 | **Deepseek OCR 2** **(3B)** |  | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Deepseek_OCR_2_(3B).ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
 
+### ERNIE Notebooks
+| Model | Type | Notebook Link |
+| --- | --- | --- |
+| **ERNIE 4 5 VL 28B A3B PT**  | Vision | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/ERNIE_4_5_VL_28B_A3B_PT_Vision.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+| **ERNIE 4 5 21B A3B PT**  | Conversational | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/ERNIE_4_5_21B_A3B_PT-Conversational.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+
+### Embedding Notebooks
+| Model | Type | Notebook Link |
+| --- | --- | --- |
+| **EmbeddingGemma** **(300M)** |  | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/EmbeddingGemma_(300M).ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+| **All MiniLM L6 v2**  |  | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/All_MiniLM_L6_v2.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+| **Qwen3 Embedding** **(4B)** |  | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Qwen3_Embedding_(4B).ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+| **Qwen3 Embedding** **(0 6B)** |  | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Qwen3_Embedding_(0_6B).ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+| **BGE M3**  |  | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/BGE_M3.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+| **ModernBert**  |  | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/ModernBert.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+| **ModernBERT** **(Large)** | Classification | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/bert_classification.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+
+### GLM Notebooks
+| Model | Type | Notebook Link |
+| --- | --- | --- |
+| **(A100) GLM Flash(80GB)**  |  | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/GLM_Flash_A100(80GB).ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+
 ### GPT-OSS Notebooks
 | Model | Type | Notebook Link |
 | --- | --- | --- |
@@ -125,9 +146,9 @@ Below are our notebooks for Google Colab categorized by model. You can view our 
 | --- | --- | --- |
 | **EmbeddingGemma** **(300M)** |  | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/EmbeddingGemma_(300M).ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
 | **FunctionGemma** **(270M)** | Tool Calling | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/FunctionGemma_(270M)-Multi-Turn-Tool-Calling.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
-| **FunctionGemma** **(270M)** |  | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/FunctionGemma_(270M).ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
-| **FunctionGemma** **(270M)** |  | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/FunctionGemma_(270M)-Mobile-Actions.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
-| **FunctionGemma** **(270M)** |  | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/FunctionGemma_(270M)-LMStudio.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+| **FunctionGemma** **(270M)** | Mobile Actions | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/FunctionGemma_(270M)-Mobile-Actions.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+| **FunctionGemma** **(270M)** | Inference | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/FunctionGemma_(270M)-LMStudio.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+| **FunctionGemma** **(270M)** | Conversational | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/FunctionGemma_(270M).ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
 | **(A100) Gemma3** **(27B)** | Conversational | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Gemma3_(27B)_A100-Conversational.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
 | **CodeGemma** **(7B)** | Conversational | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/CodeGemma_(7B)-Conversational.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
 | **Gemma3N** **(4B)** | Vision | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Gemma3N_(4B)-Vision.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
@@ -187,6 +208,17 @@ Below are our notebooks for Google Colab categorized by model. You can view our 
 | **Mistral v0.3** **(7B)** | CPT | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Mistral_v0.3_(7B)-CPT.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
 | **Mistral v0.3** **(7B)** | Alpaca | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Mistral_v0.3_(7B)-Alpaca.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
 
+### Nemotron Notebooks
+| Model | Type | Notebook Link |
+| --- | --- | --- |
+| **(A100) Nemotron Nano 3 30B A3B**  |  | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Nemotron-Nano-3-30B-A3B_A100.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+| **(A100) Nemotron 3 Nano 30B A3B**  |  | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Nemotron-3-Nano-30B-A3B_A100.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+
+### Paddle Notebooks
+| Model | Type | Notebook Link |
+| --- | --- | --- |
+| **Paddle OCR** **(1B)** | Vision | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Paddle_OCR_(1B)_Vision.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+
 ### Phi Notebooks
 | Model | Type | Notebook Link |
 | --- | --- | --- |
@@ -219,6 +251,11 @@ Below are our notebooks for Google Colab categorized by model. You can view our 
 | **Qwen2** **(7B)** | Alpaca | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Qwen2_(7B)-Alpaca.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
 | **Qwen2 VL** **(7B)** | Vision | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Qwen2_VL_(7B)-Vision.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
 
+### STT (Speech-to-Text) Notebooks
+| Model | Type | Notebook Link |
+| --- | --- | --- |
+| **Whisper** **(Large)** | Fine Tuning | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Whisper.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+
 ### TTS Notebooks
 | Model | Type | Notebook Link |
 | --- | --- | --- |
@@ -229,26 +266,35 @@ Below are our notebooks for Google Colab categorized by model. You can view our 
 | **Llasa TTS** **(1B)** | TTS | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Llasa_TTS_(1B).ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
 | **Spark TTS** **(0.5B)** | TTS | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Spark_TTS_(0_5B).ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
 
-### Whisper Notebooks
+### Vision (Multimodal) Notebooks
 | Model | Type | Notebook Link |
 | --- | --- | --- |
-| **Whisper** **(Large)** | Fine Tuning | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Whisper.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+| **Pixtral** **(12B)** | Vision | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Pixtral_(12B)-Vision.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+| **ERNIE 4 5 VL 28B A3B PT**  | Vision | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/ERNIE_4_5_VL_28B_A3B_PT_Vision.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+| **Llama3.2** **(11B)** | Vision | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Llama3.2_(11B)-Vision.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+| **Qwen3 VL** **(8B)** | Vision | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Qwen3_VL_(8B)-Vision.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+| **Qwen3 VL** **(8B)** | Vision GRPO | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Qwen3_VL_(8B)-Vision-GRPO.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+| **Ministral3 VL** **(3B)** | Vision | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Ministral_3_VL_(3B)_Vision.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+| **Gemma3N** **(4B)** | Vision | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Gemma3N_(4B)-Vision.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+| **Gemma3** **(4B)** | Vision | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Gemma3_(4B)-Vision.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+| **Gemma3** **(4B)** | Vision GRPO | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Gemma3_(4B)-Vision-GRPO.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+| **Deepseek OCR** **(3B)** | Fine Tuning | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Deepseek_OCR_(3B).ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+| **Deepseek OCR** **(3B)** | Evaluation | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Deepseek_OCR_(3B)-Evaluation.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+| **Deepseek OCR** **(3B)** | Eval | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Deepseek_OCR_(3B)-Eval.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+| **Qwen2.5 VL** **(7B)** | Vision | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Qwen2.5_VL_(7B)-Vision.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+| **Qwen2.5 VL** **(7B)** | Vision GRPO | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Qwen2_5_7B_VL_GRPO.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+| **LFM2.5 VL** **(1.6B)** | Vision | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/LFM2.5_VL_(1.6B)-Vision.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+| **Qwen2 VL** **(7B)** | Vision | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Qwen2_VL_(7B)-Vision.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+| **Deepseek OCR 2** **(3B)** |  | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Deepseek_OCR_2_(3B).ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+| **Paddle OCR** **(1B)** | Vision | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Paddle_OCR_(1B)_Vision.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
 
 ### Other Notebooks
 | Model | Type | Notebook Link |
 | --- | --- | --- |
-| **(A100) Nemotron Nano 3 30B A3B**  |  | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Nemotron-Nano-3-30B-A3B_A100.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
-| **(A100) Nemotron 3 Nano 30B A3B**  |  | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Nemotron-3-Nano-30B-A3B_A100.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
-| **(A100) GLM Flash(80GB)**  |  | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/GLM_Flash_A100(80GB).ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
-| **All MiniLM L6 v2**  |  | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/All_MiniLM_L6_v2.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
-| **ERNIE 4 5 VL 28B A3B PT**  | Vision | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/ERNIE_4_5_VL_28B_A3B_PT_Vision.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
-| **ERNIE 4 5 21B A3B PT**  | Conversational | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/ERNIE_4_5_21B_A3B_PT-Conversational.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
-| **BGE M3**  |  | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/BGE_M3.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
 | **LFM2.5** **(1.2B)** | Text Completion | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/LFM2.5_(1.2B)-Text_Completion.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
 | **LFM2.5** **(1.2B)** | Conversational | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/LFM2.5_(1.2B)-Conversational.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
 | **LFM2.5** **(1.2B)** |  | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/LFM2.5_(1.2B)-Translation.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
 | **LFM2.5 VL** **(1.6B)** | Vision | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/LFM2.5_VL_(1.6B)-Vision.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
-| **Paddle OCR** **(1B)** | Vision | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Paddle_OCR_(1B)_Vision.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
 | **Unsloth**  | Studio | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Unsloth_Studio.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
 | **Synthetic Data Hackathon**  | Synthetic Data | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Synthetic_Data_Hackathon.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
 | **NeMo Gym Sudoku**  |  | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/NeMo-Gym-Sudoku.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
@@ -290,6 +336,23 @@ Below are our notebooks for Google Colab categorized by model. You can view our 
 | **Deepseek OCR** **(3B)** | Evaluation | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Deepseek_OCR_(3B)-Evaluation.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
 | **Deepseek OCR** **(3B)** | Eval | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Deepseek_OCR_(3B)-Eval.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
 | **Deepseek OCR 2** **(3B)** |  | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Deepseek_OCR_2_(3B).ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
+
+### ERNIE Notebooks
+| Model | Type | Notebook Link |
+| --- | --- | --- |
+| **ERNIE 4 5 VL 28B A3B PT**  | Vision | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-ERNIE_4_5_VL_28B_A3B_PT_Vision.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
+| **ERNIE 4 5 21B A3B PT**  | Conversational | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-ERNIE_4_5_21B_A3B_PT-Conversational.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
+
+### Embedding Notebooks
+| Model | Type | Notebook Link |
+| --- | --- | --- |
+| **EmbeddingGemma** **(300M)** |  | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-EmbeddingGemma_(300M).ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
+| **All MiniLM L6 v2**  |  | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-All_MiniLM_L6_v2.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
+| **Qwen3 Embedding** **(4B)** |  | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Qwen3_Embedding_(4B).ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
+| **Qwen3 Embedding** **(0 6B)** |  | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Qwen3_Embedding_(0_6B).ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
+| **BGE M3**  |  | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-BGE_M3.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
+| **ModernBert**  |  | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-ModernBert.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
+| **ModernBERT** **(Large)** | Classification | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-bert_classification.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
 
 ### GPT-OSS Notebooks
 | Model | Type | Notebook Link |
@@ -360,6 +423,17 @@ Below are our notebooks for Google Colab categorized by model. You can view our 
 | **Mistral v0.3** **(7B)** | CPT | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Mistral_v0.3_(7B)-CPT.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
 | **Mistral v0.3** **(7B)** | Alpaca | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Mistral_v0.3_(7B)-Alpaca.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
 
+### Nemotron Notebooks
+| Model | Type | Notebook Link |
+| --- | --- | --- |
+| **(A100) Nemotron Nano 3 30B A3B**  |  | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Nemotron-Nano-3-30B-A3B_A100.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
+| **(A100) Nemotron 3 Nano 30B A3B**  |  | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Nemotron-3-Nano-30B-A3B_A100.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
+
+### Paddle Notebooks
+| Model | Type | Notebook Link |
+| --- | --- | --- |
+| **Paddle OCR** **(1B)** | Vision | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Paddle_OCR_(1B)_Vision.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
+
 ### Phi Notebooks
 | Model | Type | Notebook Link |
 | --- | --- | --- |
@@ -390,6 +464,11 @@ Below are our notebooks for Google Colab categorized by model. You can view our 
 | **Qwen2** **(7B)** | Alpaca | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Qwen2_(7B)-Alpaca.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
 | **Qwen2 VL** **(7B)** | Vision | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Qwen2_VL_(7B)-Vision.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
 
+### STT (Speech-to-Text) Notebooks
+| Model | Type | Notebook Link |
+| --- | --- | --- |
+| **Whisper** **(Large)** | Fine Tuning | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Whisper.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
+
 ### TTS Notebooks
 | Model | Type | Notebook Link |
 | --- | --- | --- |
@@ -400,21 +479,30 @@ Below are our notebooks for Google Colab categorized by model. You can view our 
 | **Llasa TTS** **(1B)** | TTS | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Llasa_TTS_(1B).ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
 | **Spark TTS** **(0.5B)** | TTS | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Spark_TTS_(0_5B).ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
 
-### Whisper Notebooks
+### Vision (Multimodal) Notebooks
 | Model | Type | Notebook Link |
 | --- | --- | --- |
-| **Whisper** **(Large)** | Fine Tuning | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Whisper.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
+| **Pixtral** **(12B)** | Vision | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Pixtral_(12B)-Vision.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
+| **ERNIE 4 5 VL 28B A3B PT**  | Vision | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-ERNIE_4_5_VL_28B_A3B_PT_Vision.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
+| **Llama3.2** **(11B)** | Vision | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Llama3.2_(11B)-Vision.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
+| **Qwen3 VL** **(8B)** | Vision | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Qwen3_VL_(8B)-Vision.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
+| **Qwen3 VL** **(8B)** | Vision GRPO | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Qwen3_VL_(8B)-Vision-GRPO.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
+| **Ministral3 VL** **(3B)** | Vision | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Ministral_3_VL_(3B)_Vision.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
+| **Gemma3N** **(4B)** | Vision | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Gemma3N_(4B)-Vision.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
+| **Gemma3** **(4B)** | Vision | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Gemma3_(4B)-Vision.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
+| **Gemma3** **(4B)** | Vision GRPO | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Gemma3_(4B)-Vision-GRPO.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
+| **Deepseek OCR** **(3B)** | Fine Tuning | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Deepseek_OCR_(3B).ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
+| **Deepseek OCR** **(3B)** | Evaluation | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Deepseek_OCR_(3B)-Evaluation.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
+| **Deepseek OCR** **(3B)** | Eval | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Deepseek_OCR_(3B)-Eval.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
+| **Qwen2.5 VL** **(7B)** | Vision | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Qwen2.5_VL_(7B)-Vision.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
+| **Qwen2.5 VL** **(7B)** | Vision GRPO | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Qwen2_5_7B_VL_GRPO.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
+| **Qwen2 VL** **(7B)** | Vision | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Qwen2_VL_(7B)-Vision.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
+| **Deepseek OCR 2** **(3B)** |  | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Deepseek_OCR_2_(3B).ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
+| **Paddle OCR** **(1B)** | Vision | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Paddle_OCR_(1B)_Vision.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
 
 ### Other Notebooks
 | Model | Type | Notebook Link |
 | --- | --- | --- |
-| **(A100) Nemotron Nano 3 30B A3B**  |  | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Nemotron-Nano-3-30B-A3B_A100.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
-| **(A100) Nemotron 3 Nano 30B A3B**  |  | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Nemotron-3-Nano-30B-A3B_A100.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
-| **All MiniLM L6 v2**  |  | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-All_MiniLM_L6_v2.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
-| **ERNIE 4 5 VL 28B A3B PT**  | Vision | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-ERNIE_4_5_VL_28B_A3B_PT_Vision.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
-| **ERNIE 4 5 21B A3B PT**  | Conversational | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-ERNIE_4_5_21B_A3B_PT-Conversational.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
-| **BGE M3**  |  | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-BGE_M3.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
-| **Paddle OCR** **(1B)** | Vision | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Paddle_OCR_(1B)_Vision.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
 | **Unsloth**  | Studio | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Unsloth_Studio.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
 | **CodeForces cot Finetune for Reasoning on CodeForces**  | Reasoning | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-CodeForces-cot-Finetune_for_Reasoning_on_CodeForces.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
 

--- a/nb/All_MiniLM_L6_v2.ipynb
+++ b/nb/All_MiniLM_L6_v2.ipynb
@@ -855,7 +855,8 @@
      "base_uri": "https://localhost:8080/"
     },
     "id": "2ejIt2xSNKKp",
-    "outputId": "60ab3fbf-64ce-4e04-dbb5-53793ce493ca"
+    "outputId": "60ab3fbf-64ce-4e04-dbb5-53793ce493ca",
+    "cellView": "form"
    },
    "outputs": [
     {

--- a/nb/BGE_M3.ipynb
+++ b/nb/BGE_M3.ipynb
@@ -784,7 +784,8 @@
      "base_uri": "https://localhost:8080/"
     },
     "id": "2ejIt2xSNKKp",
-    "outputId": "9972b64b-82d2-42b1-8de8-5bec538009cc"
+    "outputId": "9972b64b-82d2-42b1-8de8-5bec538009cc",
+    "cellView": "form"
    },
    "outputs": [
     {

--- a/nb/Falcon_H1_(0.5B)-Alpaca.ipynb
+++ b/nb/Falcon_H1_(0.5B)-Alpaca.ipynb
@@ -426,7 +426,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "cellView": "form"
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -737,7 +739,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "cellView": "form"
+   },
    "outputs": [
     {
      "name": "stdout",

--- a/nb/Kaggle-All_MiniLM_L6_v2.ipynb
+++ b/nb/Kaggle-All_MiniLM_L6_v2.ipynb
@@ -855,7 +855,8 @@
      "base_uri": "https://localhost:8080/"
     },
     "id": "2ejIt2xSNKKp",
-    "outputId": "60ab3fbf-64ce-4e04-dbb5-53793ce493ca"
+    "outputId": "60ab3fbf-64ce-4e04-dbb5-53793ce493ca",
+    "cellView": "form"
    },
    "outputs": [
     {

--- a/nb/Kaggle-BGE_M3.ipynb
+++ b/nb/Kaggle-BGE_M3.ipynb
@@ -784,7 +784,8 @@
      "base_uri": "https://localhost:8080/"
     },
     "id": "2ejIt2xSNKKp",
-    "outputId": "9972b64b-82d2-42b1-8de8-5bec538009cc"
+    "outputId": "9972b64b-82d2-42b1-8de8-5bec538009cc",
+    "cellView": "form"
    },
    "outputs": [
     {

--- a/nb/Kaggle-Falcon_H1_(0.5B)-Alpaca.ipynb
+++ b/nb/Kaggle-Falcon_H1_(0.5B)-Alpaca.ipynb
@@ -426,7 +426,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "cellView": "form"
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -737,7 +739,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "cellView": "form"
+   },
    "outputs": [
     {
      "name": "stdout",

--- a/nb/Kaggle-Meta-Synthetic-Data-Llama3.1_(8B).ipynb
+++ b/nb/Kaggle-Meta-Synthetic-Data-Llama3.1_(8B).ipynb
@@ -1595,7 +1595,8 @@
      "base_uri": "https://localhost:8080/"
     },
     "id": "K5O7s1eldppw",
-    "outputId": "ff284c05-397d-4b81-b341-0c462ea10a15"
+    "outputId": "ff284c05-397d-4b81-b341-0c462ea10a15",
+    "cellView": "form"
    },
    "outputs": [
     {
@@ -1919,7 +1920,8 @@
      "base_uri": "https://localhost:8080/"
     },
     "id": "SSy1iIZ4dxFS",
-    "outputId": "7b643b59-cbbe-4d3d-a659-de0709e681a8"
+    "outputId": "7b643b59-cbbe-4d3d-a659-de0709e681a8",
+    "cellView": "form"
    },
    "outputs": [
     {

--- a/nb/Kaggle-ModernBert.ipynb
+++ b/nb/Kaggle-ModernBert.ipynb
@@ -391,7 +391,8 @@
      "base_uri": "https://localhost:8080/"
     },
     "id": "2ejIt2xSNKKp",
-    "outputId": "9432934b-d3a9-40c9-ae8f-60078ddd2c57"
+    "outputId": "9432934b-d3a9-40c9-ae8f-60078ddd2c57",
+    "cellView": "form"
    },
    "outputs": [
     {

--- a/nb/Kaggle-Qwen3_Embedding_(0_6B).ipynb
+++ b/nb/Kaggle-Qwen3_Embedding_(0_6B).ipynb
@@ -684,7 +684,8 @@
      "base_uri": "https://localhost:8080/"
     },
     "id": "2ejIt2xSNKKp",
-    "outputId": "47c2d4eb-9424-4fce-87fb-87a0179f9dc0"
+    "outputId": "47c2d4eb-9424-4fce-87fb-87a0179f9dc0",
+    "cellView": "form"
    },
    "outputs": [
     {

--- a/nb/Kaggle-Qwen3_Embedding_(4B).ipynb
+++ b/nb/Kaggle-Qwen3_Embedding_(4B).ipynb
@@ -764,7 +764,8 @@
      "base_uri": "https://localhost:8080/"
     },
     "id": "2ejIt2xSNKKp",
-    "outputId": "40321ef3-81cf-4df2-d0bc-62f9d4c4587b"
+    "outputId": "40321ef3-81cf-4df2-d0bc-62f9d4c4587b",
+    "cellView": "form"
    },
    "outputs": [
     {

--- a/nb/Kaggle-Whisper.ipynb
+++ b/nb/Kaggle-Whisper.ipynb
@@ -706,7 +706,8 @@
      "base_uri": "https://localhost:8080/"
     },
     "id": "2ejIt2xSNKKp",
-    "outputId": "8563a1fd-fbb2-4d5c-d06d-120b6139439d"
+    "outputId": "8563a1fd-fbb2-4d5c-d06d-120b6139439d",
+    "cellView": "form"
    },
    "outputs": [
     {
@@ -876,7 +877,8 @@
      "base_uri": "https://localhost:8080/"
     },
     "id": "pCqnaKmlO1U9",
-    "outputId": "09b01664-eebc-4d58-c581-4ac0c7511f6e"
+    "outputId": "09b01664-eebc-4d58-c581-4ac0c7511f6e",
+    "cellView": "form"
    },
    "outputs": [
     {

--- a/nb/Kaggle-gpt-oss-(20B)-Fine-tuning.ipynb
+++ b/nb/Kaggle-gpt-oss-(20B)-Fine-tuning.ipynb
@@ -1005,7 +1005,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "cellView": "form"
+   },
    "outputs": [
     {
      "name": "stdout",

--- a/nb/Meta-Synthetic-Data-Llama3.1_(8B).ipynb
+++ b/nb/Meta-Synthetic-Data-Llama3.1_(8B).ipynb
@@ -1128,7 +1128,8 @@
      "base_uri": "https://localhost:8080/"
     },
     "id": "K5O7s1eldppw",
-    "outputId": "ff284c05-397d-4b81-b341-0c462ea10a15"
+    "outputId": "ff284c05-397d-4b81-b341-0c462ea10a15",
+    "cellView": "form"
    },
    "outputs": [
     {
@@ -1452,7 +1453,8 @@
      "base_uri": "https://localhost:8080/"
     },
     "id": "SSy1iIZ4dxFS",
-    "outputId": "7b643b59-cbbe-4d3d-a659-de0709e681a8"
+    "outputId": "7b643b59-cbbe-4d3d-a659-de0709e681a8",
+    "cellView": "form"
    },
    "outputs": [
     {

--- a/nb/ModernBert.ipynb
+++ b/nb/ModernBert.ipynb
@@ -391,7 +391,8 @@
      "base_uri": "https://localhost:8080/"
     },
     "id": "2ejIt2xSNKKp",
-    "outputId": "9432934b-d3a9-40c9-ae8f-60078ddd2c57"
+    "outputId": "9432934b-d3a9-40c9-ae8f-60078ddd2c57",
+    "cellView": "form"
    },
    "outputs": [
     {

--- a/nb/Qwen3_Embedding_(0_6B).ipynb
+++ b/nb/Qwen3_Embedding_(0_6B).ipynb
@@ -684,7 +684,8 @@
      "base_uri": "https://localhost:8080/"
     },
     "id": "2ejIt2xSNKKp",
-    "outputId": "47c2d4eb-9424-4fce-87fb-87a0179f9dc0"
+    "outputId": "47c2d4eb-9424-4fce-87fb-87a0179f9dc0",
+    "cellView": "form"
    },
    "outputs": [
     {

--- a/nb/Qwen3_Embedding_(4B).ipynb
+++ b/nb/Qwen3_Embedding_(4B).ipynb
@@ -764,7 +764,8 @@
      "base_uri": "https://localhost:8080/"
     },
     "id": "2ejIt2xSNKKp",
-    "outputId": "40321ef3-81cf-4df2-d0bc-62f9d4c4587b"
+    "outputId": "40321ef3-81cf-4df2-d0bc-62f9d4c4587b",
+    "cellView": "form"
    },
    "outputs": [
     {

--- a/nb/Whisper.ipynb
+++ b/nb/Whisper.ipynb
@@ -706,7 +706,8 @@
      "base_uri": "https://localhost:8080/"
     },
     "id": "2ejIt2xSNKKp",
-    "outputId": "8563a1fd-fbb2-4d5c-d06d-120b6139439d"
+    "outputId": "8563a1fd-fbb2-4d5c-d06d-120b6139439d",
+    "cellView": "form"
    },
    "outputs": [
     {
@@ -876,7 +877,8 @@
      "base_uri": "https://localhost:8080/"
     },
     "id": "pCqnaKmlO1U9",
-    "outputId": "09b01664-eebc-4d58-c581-4ac0c7511f6e"
+    "outputId": "09b01664-eebc-4d58-c581-4ac0c7511f6e",
+    "cellView": "form"
    },
    "outputs": [
     {

--- a/nb/gpt-oss-(20B)-Fine-tuning.ipynb
+++ b/nb/gpt-oss-(20B)-Fine-tuning.ipynb
@@ -1005,7 +1005,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "cellView": "form"
+   },
    "outputs": [
     {
      "name": "stdout",

--- a/original_template/All_MiniLM_L6_v2.ipynb
+++ b/original_template/All_MiniLM_L6_v2.ipynb
@@ -833,7 +833,8 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "2ejIt2xSNKKp",
-        "outputId": "60ab3fbf-64ce-4e04-dbb5-53793ce493ca"
+        "outputId": "60ab3fbf-64ce-4e04-dbb5-53793ce493ca",
+        "cellView": "form"
       },
       "outputs": [
         {

--- a/original_template/BGE_M3.ipynb
+++ b/original_template/BGE_M3.ipynb
@@ -762,7 +762,8 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "2ejIt2xSNKKp",
-        "outputId": "9972b64b-82d2-42b1-8de8-5bec538009cc"
+        "outputId": "9972b64b-82d2-42b1-8de8-5bec538009cc",
+        "cellView": "form"
       },
       "outputs": [
         {

--- a/original_template/Falcon_H1_(0.5B)-Alpaca.ipynb
+++ b/original_template/Falcon_H1_(0.5B)-Alpaca.ipynb
@@ -420,7 +420,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "cellView": "form"
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -731,7 +733,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "cellView": "form"
+   },
    "outputs": [
     {
      "name": "stdout",

--- a/original_template/Meta-Synthetic-Data-Llama3.1_(8B).ipynb
+++ b/original_template/Meta-Synthetic-Data-Llama3.1_(8B).ipynb
@@ -1106,7 +1106,8 @@
      "base_uri": "https://localhost:8080/"
     },
     "id": "K5O7s1eldppw",
-    "outputId": "ff284c05-397d-4b81-b341-0c462ea10a15"
+    "outputId": "ff284c05-397d-4b81-b341-0c462ea10a15",
+    "cellView": "form"
    },
    "outputs": [
     {
@@ -1430,7 +1431,8 @@
      "base_uri": "https://localhost:8080/"
     },
     "id": "SSy1iIZ4dxFS",
-    "outputId": "7b643b59-cbbe-4d3d-a659-de0709e681a8"
+    "outputId": "7b643b59-cbbe-4d3d-a659-de0709e681a8",
+    "cellView": "form"
    },
    "outputs": [
     {

--- a/original_template/ModernBert.ipynb
+++ b/original_template/ModernBert.ipynb
@@ -369,7 +369,8 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "2ejIt2xSNKKp",
-        "outputId": "9432934b-d3a9-40c9-ae8f-60078ddd2c57"
+        "outputId": "9432934b-d3a9-40c9-ae8f-60078ddd2c57",
+        "cellView": "form"
       },
       "outputs": [
         {

--- a/original_template/Qwen3_Embedding_(0_6B).ipynb
+++ b/original_template/Qwen3_Embedding_(0_6B).ipynb
@@ -662,7 +662,8 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "2ejIt2xSNKKp",
-        "outputId": "47c2d4eb-9424-4fce-87fb-87a0179f9dc0"
+        "outputId": "47c2d4eb-9424-4fce-87fb-87a0179f9dc0",
+        "cellView": "form"
       },
       "outputs": [
         {

--- a/original_template/Qwen3_Embedding_(4B).ipynb
+++ b/original_template/Qwen3_Embedding_(4B).ipynb
@@ -742,7 +742,8 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "2ejIt2xSNKKp",
-        "outputId": "40321ef3-81cf-4df2-d0bc-62f9d4c4587b"
+        "outputId": "40321ef3-81cf-4df2-d0bc-62f9d4c4587b",
+        "cellView": "form"
       },
       "outputs": [
         {

--- a/original_template/Whisper.ipynb
+++ b/original_template/Whisper.ipynb
@@ -718,7 +718,8 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "2ejIt2xSNKKp",
-        "outputId": "8563a1fd-fbb2-4d5c-d06d-120b6139439d"
+        "outputId": "8563a1fd-fbb2-4d5c-d06d-120b6139439d",
+        "cellView": "form"
       },
       "outputs": [
         {
@@ -888,7 +889,8 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "pCqnaKmlO1U9",
-        "outputId": "09b01664-eebc-4d58-c581-4ac0c7511f6e"
+        "outputId": "09b01664-eebc-4d58-c581-4ac0c7511f6e",
+        "cellView": "form"
       },
       "outputs": [
         {

--- a/original_template/gpt-oss-(20B)-Fine-tuning.ipynb
+++ b/original_template/gpt-oss-(20B)-Fine-tuning.ipynb
@@ -983,7 +983,9 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "cellView": "form"
+      },
       "outputs": [
         {
           "name": "stdout",


### PR DESCRIPTION
## Summary

Refactors `update_all_notebooks.py` for maintainability, adds CRLF safety, and revamps README auto-generated sections with cross-cutting categories. Also hides memory stats cells behind `cellView=form` so they collapse in Colab.

## Changes

### Script reordering (Step 9)
- Moved frequently-edited content to the top of `update_all_notebooks.py`: news/announcements, version pins, install cells, footer content, architecture/type mappings, exceptions list, and name mappings
- Added clear section separators (`FREQUENTLY EDITED CONTENT` / `INTERNAL IMPLEMENTATION`)
- Makes future news/install/mapping changes much easier to find

### CRLF/LF handling (Step 4)
- Added `newline=""` to all ~20 `open()` calls in both `update_all_notebooks.py` and `scripts/fix_templates.py`
- Normalize CRLF and bare CR sequences to LF in `_source_lines()`
- Added `.gitattributes` enforcing `eol=lf` for notebooks, Python, markdown, and JSON

### README revamp (Step 8)
- Added cross-cutting sections: **Vision (Multimodal)** and **Embedding** -- notebooks can now appear in both their architecture section and relevant cross-cutting sections
- Added new architecture sections: ERNIE, Nemotron, Paddle, GLM
- Renamed "Whisper Notebooks" to "STT (Speech-to-Text) Notebooks"
- Fixed FunctionGemma having blank types by adding `FIRST_MAPPING_NAME` entries and `Mobile Actions` to `KNOWN_TYPES_ORDERED`
- Removed duplicate Oute-TTS row in the manual TTS section

### Memory stats cells (Step 7)
- `scripts/fix_templates.py`: new `fix_memory_stats_cellview()` sets `metadata.cellView = "form"` on cells containing "Show current memory stats" or "Show final memory" (12 template cells fixed)
- `update_all_notebooks.py`: new `_ensure_memory_stats_hidden()` enforces the same on generated notebooks (321 cells across all generated notebooks)

### Dead code removal (Step 1)
- Removed `get_current_git_branch()` (never called)
- Removed `copy_folder()` (never called)
- Removed redundant `import re` at line 2240

### Other improvements
- Auto-detect worker count: `--workers` default changed from 1 to 0 (auto), which resolves to `max(2, min(os.cpu_count(), 32))`
- Added `_summarize_git_diff()` at end of `__main__` to print categorized diff summary (news-only, install-only, README, new, other)
- Fixed 4 `docs.unsloth.ai` URLs to `unsloth.ai/docs/` in announcement
- Added `.strip()` to news content assignment (defensive)
- Documented all `DONT_UPDATE_EXCEPTIONS` entries with inline comments

## Notebook changes

- 18 notebooks (9 Colab + 9 Kaggle) updated with `cellView: "form"` on memory stats cells
- README.md regenerated with new sections and cross-cutting categories

## Verification

- `python scripts/fix_templates.py` -- 12 template cells fixed
- `python update_all_notebooks.py` -- all notebooks regenerated successfully
- 321/321 memory stats cells in `nb/` have `cellView: "form"`
- 0 files contain CRLF
- README has all expected sections: Vision (Multimodal), Embedding, STT (Speech-to-Text), ERNIE, Nemotron, Paddle, GLM
- FunctionGemma rows have 4 distinct types (Conversational, Inference, Mobile Actions, Tool Calling)
- No duplicate Oute-TTS rows