### PR TITLE
Fix two notebooks for script conversion

### DIFF
--- a/nb/CodeForces-cot-Finetune_for_Reasoning_on_CodeForces.ipynb
+++ b/nb/CodeForces-cot-Finetune_for_Reasoning_on_CodeForces.ipynb
@@ -50,7 +50,19 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "%%capture\nimport os, re\nif \"COLAB_\" not in \"\".join(os.environ.keys()):\n    !pip install unsloth  # Do this in local & cloud setups\nelse:\n    import torch; v = re.match(r'[\\d]{1,}\\.[\\d]{1,}', str(torch.__version__)).group(0)\n    xformers = 'xformers==' + {'2.10':'0.0.34','2.9':'0.0.33.post1','2.8':'0.0.32.post2'}.get(v, \"0.0.34\")\n    !pip install sentencepiece protobuf \"datasets==4.3.0\" \"huggingface_hub>=0.34.0\" hf_transfer\n    !pip install --no-deps unsloth_zoo bitsandbytes accelerate {xformers} peft trl triton unsloth\n!pip install transformers==4.56.2\n!pip install --no-deps trl==0.22.2"
+   "source": [
+    "%%capture\n",
+    "import os, re\n",
+    "if \"COLAB_\" not in \"\".join(os.environ.keys()):\n",
+    "    !pip install unsloth  # Do this in local & cloud setups\n",
+    "else:\n",
+    "    import torch; v = re.match(r'[\\d]{1,}\\.[\\d]{1,}', str(torch.__version__)).group(0)\n",
+    "    xformers = 'xformers==' + {'2.10':'0.0.34','2.9':'0.0.33.post1','2.8':'0.0.32.post2'}.get(v, \"0.0.34\")\n",
+    "    !pip install sentencepiece protobuf \"datasets==4.3.0\" \"huggingface_hub>=0.34.0\" hf_transfer\n",
+    "    !pip install --no-deps unsloth_zoo bitsandbytes accelerate {xformers} peft trl triton unsloth\n",
+    "!pip install transformers==4.56.2\n",
+    "!pip install --no-deps trl==0.22.2"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1366,6 +1378,18 @@
    },
    "source": [
     "Now if you want to load the LoRA adapters we just saved for inference, set `False` to `True`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Prompt template used by the inference cell below.\n",
+    "# Some tutorials show this in markdown as \"copy from above\"; define it\n",
+    "# explicitly so the notebook runs end-to-end.\n",
+    "alpaca_prompt = \"\"\"Below is an instruction that describes a task, paired with an input that provides further context. Write a response that appropriately completes the request.\n\n### Instruction:\n{}\n\n### Input:\n{}\n\n### Response:\n{}\"\"\"\n"
    ]
   },
   {

--- a/nb/EmbeddingGemma_(300M).ipynb
+++ b/nb/EmbeddingGemma_(300M).ipynb
@@ -58,7 +58,19 @@
     "id": "Xk9jtF3J9Xa_"
    },
    "outputs": [],
-   "source": "%%capture\nimport os, re\nif \"COLAB_\" not in \"\".join(os.environ.keys()):\n    !pip install unsloth  # Do this in local & cloud setups\nelse:\n    import torch; v = re.match(r'[\\d]{1,}\\.[\\d]{1,}', str(torch.__version__)).group(0)\n    xformers = 'xformers==' + {'2.10':'0.0.34','2.9':'0.0.33.post1','2.8':'0.0.32.post2'}.get(v, \"0.0.34\")\n    !pip install sentencepiece protobuf \"datasets==4.3.0\" \"huggingface_hub>=0.34.0\" hf_transfer\n    !pip install --no-deps unsloth_zoo bitsandbytes accelerate {xformers} peft trl triton unsloth\n!pip install transformers==4.56.2\n!pip install --no-deps trl==0.22.2"
+   "source": [
+    "%%capture\n",
+    "import os, re\n",
+    "if \"COLAB_\" not in \"\".join(os.environ.keys()):\n",
+    "    !pip install unsloth  # Do this in local & cloud setups\n",
+    "else:\n",
+    "    import torch; v = re.match(r'[\\d]{1,}\\.[\\d]{1,}', str(torch.__version__)).group(0)\n",
+    "    xformers = 'xformers==' + {'2.10':'0.0.34','2.9':'0.0.33.post1','2.8':'0.0.32.post2'}.get(v, \"0.0.34\")\n",
+    "    !pip install sentencepiece protobuf \"datasets==4.3.0\" \"huggingface_hub>=0.34.0\" hf_transfer\n",
+    "    !pip install --no-deps unsloth_zoo bitsandbytes accelerate {xformers} peft trl triton unsloth\n",
+    "!pip install transformers==4.56.2\n",
+    "!pip install --no-deps trl==0.22.2"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -396,7 +408,13 @@
     "    show_progress_bar = False,\n",
     "    batch_size = 64,\n",
     ")\n",
-    "with torch.autocast(device_type = \"cuda\", dtype = model.dtype, enabled = model.dtype != torch.float16):\n",
+    "_autocast_dtype = getattr(model, 'dtype', None)\n",
+    "if _autocast_dtype is None:\n",
+    "    try:\n",
+    "        _autocast_dtype = next(model.parameters()).dtype\n",
+    "    except Exception:\n",
+    "        _autocast_dtype = torch.float32\n",
+    "with torch.autocast(device_type = \"cuda\", dtype = _autocast_dtype, enabled = _autocast_dtype != torch.float16):\n",
     "    print(evaluator(model))"
    ]
   },
@@ -817,7 +835,13 @@
     }
    ],
    "source": [
-    "with torch.autocast(device_type = \"cuda\", dtype = model.dtype, enabled = model.dtype != torch.float16):\n",
+    "_autocast_dtype = getattr(model, 'dtype', None)\n",
+    "if _autocast_dtype is None:\n",
+    "    try:\n",
+    "        _autocast_dtype = next(model.parameters()).dtype\n",
+    "    except Exception:\n",
+    "        _autocast_dtype = torch.float32\n",
+    "with torch.autocast(device_type = \"cuda\", dtype = _autocast_dtype, enabled = _autocast_dtype != torch.float16):\n",
     "    print(evaluator(model))"
    ]
   },


### PR DESCRIPTION
## Summary

These changes make two notebooks run end-to-end when converted to a Python script:

- CodeForces-cot-Finetune_for_Reasoning_on_CodeForces.ipynb
  - Define alpaca_prompt in an executed cell (the inference cell uses alpaca_prompt.format).
- EmbeddingGemma_(300M).ipynb
  - Replace model.dtype usage in torch.autocast with a robust dtype fallback (SentenceTransformer does not always expose .dtype).

## Why

The notebook suite runner converts ipynb to py and executes cells as-is. Both of the above cases currently fail after conversion.

## Notes

No behavior change to training itself; this only fixes the post-training/inference paths.
