### PR TITLE
Gemma3N audio notebooks: bound test index and subset size

### DIFF
--- a/nb/Gemma3N_(4B)-Audio.ipynb
+++ b/nb/Gemma3N_(4B)-Audio.ipynb
@@ -242,10 +242,15 @@
     "dataset = load_dataset(\"kadirnar/Emilia-DE-B000000\", split = \"train\")\n",
     "\n",
     "# Select a single audio sample to reserve for testing.\n",
-    "# This index is chosen from the full dataset before we create the smaller training split.\n",
-    "test_audio = dataset[7546]\n",
+    "# Use a bounded index so this works on smaller dataset slices too.\n",
+    "dataset_len = len(dataset)\n",
+    "if dataset_len == 0:\n",
+    "    raise ValueError(\"Loaded dataset is empty; cannot select test audio or training subset.\")\n",
     "\n",
-    "dataset = dataset.select(range(3000))\n",
+    "test_audio_index = min(7546, dataset_len - 1)\n",
+    "test_audio = dataset[test_audio_index]\n",
+    "\n",
+    "dataset = dataset.select(range(min(3000, dataset_len)))\n",
     "\n",
     "dataset = dataset.cast_column(\"audio\", Audio(sampling_rate = 16000))"
    ]

--- a/nb/Kaggle-Gemma3N_(4B)-Audio.ipynb
+++ b/nb/Kaggle-Gemma3N_(4B)-Audio.ipynb
@@ -242,10 +242,15 @@
     "dataset = load_dataset(\"kadirnar/Emilia-DE-B000000\", split = \"train\")\n",
     "\n",
     "# Select a single audio sample to reserve for testing.\n",
-    "# This index is chosen from the full dataset before we create the smaller training split.\n",
-    "test_audio = dataset[7546]\n",
+    "# Use a bounded index so this works on smaller dataset slices too.\n",
+    "dataset_len = len(dataset)\n",
+    "if dataset_len == 0:\n",
+    "    raise ValueError(\"Loaded dataset is empty; cannot select test audio or training subset.\")\n",
     "\n",
-    "dataset = dataset.select(range(3000))\n",
+    "test_audio_index = min(7546, dataset_len - 1)\n",
+    "test_audio = dataset[test_audio_index]\n",
+    "\n",
+    "dataset = dataset.select(range(min(3000, dataset_len)))\n",
     "\n",
     "dataset = dataset.cast_column(\"audio\", Audio(sampling_rate = 16000))"
    ]

--- a/original_template/Gemma3N_(4B)-Audio.ipynb
+++ b/original_template/Gemma3N_(4B)-Audio.ipynb
@@ -218,10 +218,15 @@
     "dataset = load_dataset(\"kadirnar/Emilia-DE-B000000\", split=\"train\")\n",
     "\n",
     "# Select a single audio sample to reserve for testing.\n",
-    "# This index is chosen from the full dataset before we create the smaller training split.\n",
-    "test_audio = dataset[7546]\n",
+    "# Use a bounded index so this works on smaller dataset slices too.\n",
+    "dataset_len = len(dataset)\n",
+    "if dataset_len == 0:\n",
+    "    raise ValueError(\"Loaded dataset is empty; cannot select test audio or training subset.\")\n",
     "\n",
-    "dataset = dataset.select(range(3000))\n",
+    "test_audio_index = min(7546, dataset_len - 1)\n",
+    "test_audio = dataset[test_audio_index]\n",
+    "\n",
+    "dataset = dataset.select(range(min(3000, dataset_len)))\n",
     "\n",
     "dataset = dataset.cast_column(\"audio\", Audio(sampling_rate=16000))"
    ]

--- a/python_scripts/Gemma3N_(4B)-Audio.py
+++ b/python_scripts/Gemma3N_(4B)-Audio.py
@@ -110,10 +110,15 @@ from datasets import load_dataset,Audio,concatenate_datasets
 dataset = load_dataset("kadirnar/Emilia-DE-B000000", split = "train")
 
 # Select a single audio sample to reserve for testing.
-# This index is chosen from the full dataset before we create the smaller training split.
-test_audio = dataset[7546]
+# Use a bounded index so this works on smaller dataset slices too.
+dataset_len = len(dataset)
+if dataset_len == 0:
+    raise ValueError("Loaded dataset is empty; cannot select test audio or training subset.")
 
-dataset = dataset.select(range(3000))
+test_audio_index = min(7546, dataset_len - 1)
+test_audio = dataset[test_audio_index]
+
+dataset = dataset.select(range(min(3000, dataset_len)))
 
 dataset = dataset.cast_column("audio", Audio(sampling_rate = 16000))
 

--- a/python_scripts/Kaggle-Gemma3N_(4B)-Audio.py
+++ b/python_scripts/Kaggle-Gemma3N_(4B)-Audio.py
@@ -110,10 +110,15 @@ from datasets import load_dataset,Audio,concatenate_datasets
 dataset = load_dataset("kadirnar/Emilia-DE-B000000", split = "train")
 
 # Select a single audio sample to reserve for testing.
-# This index is chosen from the full dataset before we create the smaller training split.
-test_audio = dataset[7546]
+# Use a bounded index so this works on smaller dataset slices too.
+dataset_len = len(dataset)
+if dataset_len == 0:
+    raise ValueError("Loaded dataset is empty; cannot select test audio or training subset.")
 
-dataset = dataset.select(range(3000))
+test_audio_index = min(7546, dataset_len - 1)
+test_audio = dataset[test_audio_index]
+
+dataset = dataset.select(range(min(3000, dataset_len)))
 
 dataset = dataset.cast_column("audio", Audio(sampling_rate = 16000))
 


### PR DESCRIPTION
## Summary
- makes Gemma3N audio notebook sampling robust to smaller dataset sizes
- applies the same fix to notebook, Kaggle notebook, template, and generated python scripts

## Root Cause
The notebooks assumed a large dataset and used:
- `test_audio = dataset[7546]`
- `dataset = dataset.select(range(3000))`

When the dataset is smaller (for example in smoke or subset runs), this can raise out-of-bounds errors.

## Changes
Updated the following files:
- `nb/Gemma3N_(4B)-Audio.ipynb`
- `nb/Kaggle-Gemma3N_(4B)-Audio.ipynb`
- `original_template/Gemma3N_(4B)-Audio.ipynb`
- `python_scripts/Gemma3N_(4B)-Audio.py`
- `python_scripts/Kaggle-Gemma3N_(4B)-Audio.py`

New logic:
- compute `dataset_len = len(dataset)`
- fail early with clear message if dataset is empty
- use `test_audio_index = min(7546, dataset_len - 1)`
- use `dataset.select(range(min(3000, dataset_len)))`

## Validation
- `python -m compileall python_scripts/Gemma3N_(4B)-Audio.py python_scripts/Kaggle-Gemma3N_(4B)-Audio.py`
- static assertions confirm legacy hardcoded indexing patterns were removed from both notebook variants

## Notes
- behavior is unchanged for large datasets
- this only affects boundary handling for smaller datasets
