### PR TITLE
Update Whisper notebook to use AutoModelForSpeechSeq2Seq

### DIFF
--- a/nb/Whisper.ipynb
+++ b/nb/Whisper.ipynb
@@ -328,7 +328,7 @@
    ],
    "source": [
     "from unsloth import FastModel\n",
-    "from transformers import WhisperForConditionalGeneration\n",
+    "from transformers import AutoModelForSpeechSeq2Seq\n",
     "import torch\n",
     "\n",
     "fourbit_models = [\n",
@@ -351,7 +351,7 @@
     "    model_name = \"unsloth/whisper-large-v3\",\n",
     "    dtype = None, # Leave as None for auto detection\n",
     "    load_in_4bit = False, # Set to True to do 4bit quantization which reduces memory\n",
-    "    auto_model = WhisperForConditionalGeneration,\n",
+    "    auto_model = AutoModelForSpeechSeq2Seq,\n",
     "    whisper_language = \"English\",\n",
     "    whisper_task = \"transcribe\",\n",
     "    # token = \"YOUR_HF_TOKEN\", # HF Token for gated models\n",


### PR DESCRIPTION
## Summary
This updates `nb/Whisper.ipynb` to use the canonical auto model class for Whisper loading.

## Changes
- Replaced:
  - `from transformers import WhisperForConditionalGeneration`
  - `auto_model = WhisperForConditionalGeneration`
- With:
  - `from transformers import AutoModelForSpeechSeq2Seq`
  - `auto_model = AutoModelForSpeechSeq2Seq`

## Why
`FastModel.from_pretrained` expects `auto_model` usage that is consistent with AutoModel factories. Using `AutoModelForSpeechSeq2Seq` makes the notebook robust and aligned with the loader path.

## Validation
- Confirmed notebook cell source now references `AutoModelForSpeechSeq2Seq` for both import and `auto_model` argument.
- Runtime smoke on patched loader path succeeds for this AutoModel setting.

## Related
- Companion unsloth fix PR: https://github.com/unslothai/unsloth/pull/4115
