### PR TITLE
Open header banner links (Colab / Discord / Docs / logo) in a new tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 <div align="center">
 
-  <a href="https://unsloth.ai"><picture>
+  <a href="https://unsloth.ai" target="_blank" rel="noopener noreferrer"><picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/unslothai/unsloth/main/images/unsloth%20logo%20white%20text.png">
     <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/unslothai/unsloth/main/images/unsloth%20logo%20black%20text.png">
     <img alt="unsloth logo" src="https://raw.githubusercontent.com/unslothai/unsloth/main/images/unsloth%20logo%20black%20text.png" height="110" style="max-width: 100%;">
   </picture></a>
   
-<a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/gpt-oss-(20B)-Fine-tuning.ipynb"><img src="https://raw.githubusercontent.com/unslothai/unsloth/main/images/start free finetune button.png" height="48"></a>
-<a href="https://discord.gg/unsloth"><img src="https://raw.githubusercontent.com/unslothai/unsloth/main/images/Discord button.png" height="48"></a>
-<a href="https://unsloth.ai/docs/get-started/unsloth-notebooks"><img src="https://raw.githubusercontent.com/unslothai/unsloth/refs/heads/main/images/Documentation%20Button.png" height="48"></a>
+<a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/gpt-oss-(20B)-Fine-tuning.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/unslothai/unsloth/main/images/start free finetune button.png" height="48"></a>
+<a href="https://discord.gg/unsloth" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/unslothai/unsloth/main/images/Discord button.png" height="48"></a>
+<a href="https://unsloth.ai/docs/get-started/unsloth-notebooks" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/unslothai/unsloth/refs/heads/main/images/Documentation%20Button.png" height="48"></a>
 
 </div>
 


### PR DESCRIPTION
## Summary

The four hand-written header image anchors at the very top of the README were the only anchors still missing `target="_blank"`. This PR adds `target="_blank" rel="noopener noreferrer"` to each of them so every clickable image in the README (header buttons plus every Colab and Kaggle badge in the generated tables) opens in a new browser tab.

## Anchors updated

- Unsloth logo
- "Start free finetune" Colab button
- Discord button
- Documentation button

Full coverage after this change:
- Header (hand-written): all anchors have `target="_blank"` (this PR).
- Main Notebooks table (hand-written): already done in #247.
- Specific use-case Notebooks static block: already done in #247 at the source in `update_all_notebooks.py`.
- Every auto-generated Colab and Kaggle row under the `<!-- START OF EDITING -->` marker: already renders `<a target="_blank" rel="noopener noreferrer">` from the script.

## Idempotency

The script is not touched by this PR. Running `python update_all_notebooks.py --no-progress --workers 4` on top of this branch produces no README diff (verified locally with `diff -q` before and after a run). The new-tab behaviour survives regeneration.

## Test plan

- [ ] Open the README preview on GitHub and click each of the four header buttons: each should open in a new tab.
- [ ] Click a Main Notebooks Colab badge: new tab.
- [ ] Click a Specific use-case Notebooks badge: new tab.
- [ ] Click a Kaggle badge in the Kaggle section: new tab.
- [ ] Run `python update_all_notebooks.py` locally and confirm the README is byte-identical afterwards.