### PR TITLE
molab: top popular notebooks in README, rest collapsible

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,6 +722,20 @@ Run any of these on [molab](https://molab.marimo.io), Marimo's hosted GPU notebo
 
 | Notebook | Open |
 | --- | --- |
+| Unsloth Studio | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Unsloth_Studio.py) |
+| Gemma4 (E2B) - Vision | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Gemma4_(E2B)-Vision.py) |
+| Qwen3 5 (4B) Vision | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Qwen3_5_(4B)_Vision.py) |
+| Qwen3 5 (2B) Vision | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Qwen3_5_(2B)_Vision.py) |
+| gpt - oss - (20B) - Fine - tuning | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/gpt-oss-(20B)-Fine-tuning.py) |
+| gpt - oss - (20B) - GRPO | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/gpt-oss-(20B)-GRPO.py) |
+
+<details>
+  <summary>
+    Click for all our molab notebooks:
+  </summary>
+
+| Notebook | Open |
+| --- | --- |
 | All MiniLM L6 v2 | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/All_MiniLM_L6_v2.py) |
 | BGE M3 | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/BGE_M3.py) |
 | CodeForces - cot - Finetune for Reasoning on CodeForces | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/CodeForces-cot-Finetune_for_Reasoning_on_CodeForces.py) |
@@ -759,7 +773,6 @@ Run any of these on [molab](https://molab.marimo.io), Marimo's hosted GPU notebo
 | Gemma4 (31B) - Vision | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Gemma4_(31B)-Vision.py) |
 | Gemma4 (E2B) - Audio | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Gemma4_(E2B)-Audio.py) |
 | Gemma4 (E2B) - Text | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Gemma4_(E2B)-Text.py) |
-| Gemma4 (E2B) - Vision | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Gemma4_(E2B)-Vision.py) |
 | Gemma4 (E2B) Reinforcement Learning 2048 Game | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Gemma4_(E2B)_Reinforcement_Learning_2048_Game.py) |
 | Gemma4 (E2B) Reinforcement Learning Sudoku Game | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Gemma4_(E2B)_Reinforcement_Learning_Sudoku_Game.py) |
 | Gemma4 (E4B) - Audio | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Gemma4_(E4B)-Audio.py) |
@@ -829,8 +842,6 @@ Run any of these on [molab](https://molab.marimo.io), Marimo's hosted GPU notebo
 | Qwen3 (4B) - Thinking | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Qwen3_(4B)-Thinking.py) |
 | Qwen3 (4B) Instruct - QAT | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Qwen3_(4B)_Instruct-QAT.py) |
 | Qwen3 5 (0 8B) Vision | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Qwen3_5_(0_8B)_Vision.py) |
-| Qwen3 5 (2B) Vision | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Qwen3_5_(2B)_Vision.py) |
-| Qwen3 5 (4B) Vision | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Qwen3_5_(4B)_Vision.py) |
 | Qwen3 5 (4B) Vision GRPO | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Qwen3_5_(4B)_Vision_GRPO.py) |
 | Qwen3 5 MoE | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Qwen3_5_MoE.py) |
 | Qwen3 6 MoE | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Qwen3_6_MoE.py) |
@@ -845,13 +856,10 @@ Run any of these on [molab](https://molab.marimo.io), Marimo's hosted GPU notebo
 | Synthetic Data Hackathon | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Synthetic_Data_Hackathon.py) |
 | TinyLlama (1.1B) — Alpaca | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/TinyLlama_(1.1B)-Alpaca.py) |
 | TinyQwen3 MoE | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/TinyQwen3_MoE.py) |
-| Unsloth Studio | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Unsloth_Studio.py) |
 | Whisper | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Whisper.py) |
 | Zephyr (7B) - DPO | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Zephyr_(7B)-DPO.py) |
 | bert classification | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/bert_classification.py) |
 | gpt - oss - (120B) A100 - Fine - tuning | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/gpt-oss-(120B)_A100-Fine-tuning.py) |
-| gpt - oss - (20B) - Fine - tuning | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/gpt-oss-(20B)-Fine-tuning.py) |
-| gpt - oss - (20B) - GRPO | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/gpt-oss-(20B)-GRPO.py) |
 | gpt - oss - (20B) A100 - GRPO | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/gpt-oss-(20B)_A100-GRPO.py) |
 | gpt oss (20B) 500K Context Fine tuning | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/gpt_oss_(20B)_500K_Context_Fine_tuning.py) |
 | gpt oss (20B) GRPO BF16 | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/gpt_oss_(20B)_GRPO_BF16.py) |
@@ -859,6 +867,7 @@ Run any of these on [molab](https://molab.marimo.io), Marimo's hosted GPU notebo
 | gpt oss (20B) Reinforcement Learning 2048 Game BF16 | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/gpt_oss_(20B)_Reinforcement_Learning_2048_Game_BF16.py) |
 | gpt oss (20B) Reinforcement Learning 2048 Game DGX Spark | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/gpt_oss_(20B)_Reinforcement_Learning_2048_Game_DGX_Spark.py) |
 | gpt oss (20B) Reinforcement Learning GRPO Minesweeper Game BF16 | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/gpt_oss_(20B)_Reinforcement_Learning_GRPO_Minesweeper_Game_BF16.py) |
+</details>
 <!-- MOLAB:END -->
 
 ## Known Issues / Environment Notes

--- a/scripts/molab_generate.py
+++ b/scripts/molab_generate.py
@@ -1455,6 +1455,52 @@ def _load_generation_status() -> dict[str, str]:
     return data if isinstance(data, dict) else {}
 
 
+# Most popular molab notebooks shown in the top README table before the rest
+# fold into a collapsible <details>. Matches the AMD section's top-6.
+_MOLAB_POPULAR_COUNT = 6
+
+
+def _popular_molab_stems(available: list["molab_manifest.MolabNotebook"]) -> list[str]:
+    """Return the stems of the most popular molab notebooks.
+
+    Like the AMD section: the molab siblings of the hand-written
+    ``### Main Notebooks`` README table, in Main order, capped at
+    ``_MOLAB_POPULAR_COUNT``. Only stems present in ``available`` are kept, so a
+    sibling with no molab output (e.g. a vllm/GRPO notebook) is skipped. Returns
+    ``[]`` if the README or its Main Notebooks block is missing, so the renderer
+    falls back to a single flat table.
+    """
+    import urllib.parse
+
+    readme_path = _REPO_ROOT / "README.md"
+    try:
+        readme = readme_path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+
+    main_match = re.search(
+        r"^### Main Notebooks\b(.*?)(?=^### |^# |^<!--|\Z)",
+        readme,
+        re.MULTILINE | re.DOTALL,
+    )
+    if not main_match:
+        return []
+
+    available_stems = {nb.output.stem for nb in available}
+    popular: list[str] = []
+    for url_match in re.finditer(
+        r"/blob/main/nb/([^)\s\"']+\.ipynb)", main_match.group(1)
+    ):
+        # Main Notebook URLs encode parens as %28/%29; unquote so the stem
+        # matches the manifest stem (e.g. Gemma4_(E2B)-Vision).
+        stem = urllib.parse.unquote(url_match.group(1))[: -len(".ipynb")]
+        if stem in available_stems and stem not in popular:
+            popular.append(stem)
+        if len(popular) >= _MOLAB_POPULAR_COUNT:
+            break
+    return popular
+
+
 def render_readme_section() -> str:
     """Return the molab README section body (no markers) by delegating to
     readme-implementer's pure renderer.
@@ -1467,6 +1513,10 @@ def render_readme_section() -> str:
 
     The on-disk ``output.exists()`` check is a belt-and-braces secondary
     guard: if the status file is stale, a missing file is still excluded.
+
+    The most popular notebooks (the molab siblings of the README Main Notebooks
+    table) are surfaced in a short top table while the rest fold into a
+    collapsible ``<details>``, mirroring the AMD Notebooks section.
     """
     import molab_readme
 
@@ -1476,7 +1526,9 @@ def render_readme_section() -> str:
         for nb in molab_manifest.get_active_notebooks()
         if status.get(nb.output.stem) == "ok" and nb.output.exists()
     ]
-    return molab_readme.render_molab_readme_section(available)
+    return molab_readme.render_molab_readme_section(
+        available, popular_stems=_popular_molab_stems(available)
+    )
 
 
 def update_readme(readme_path: Path | None = None) -> bool:

--- a/scripts/molab_readme.py
+++ b/scripts/molab_readme.py
@@ -64,7 +64,29 @@ def _badge_markdown(nb: "MolabNotebook") -> str:
     return f"[![Open in molab]({_BADGE_IMAGE})]({url})"
 
 
-def render_molab_readme_section(notebooks: Iterable["MolabNotebook"]) -> str:
+def _row(nb: "MolabNotebook") -> str:
+    """Return one markdown table row for a notebook.
+
+    Column layout mirrors the existing Main Notebooks table: Notebook | Open.
+    """
+    return f"| {nb.display_name} | {_badge_markdown(nb)} |"
+
+
+_INTRO = (
+    "## Open in molab\n"
+    "\n"
+    "Run any of these on [molab](https://molab.marimo.io), Marimo's "
+    "hosted GPU notebooks. They're reactive: change a value in one "
+    "cell, the cells below recompute on their own.\n"
+    "\n"
+)
+_TABLE_HEADER = "| Notebook | Open |\n| --- | --- |\n"
+
+
+def render_molab_readme_section(
+    notebooks: Iterable["MolabNotebook"],
+    popular_stems: "list[str] | None" = None,
+) -> str:
     """Render the molab README section as a markdown string.
 
     Parameters
@@ -75,6 +97,12 @@ def render_molab_readme_section(notebooks: Iterable["MolabNotebook"]) -> str:
         ``molab_manifest.get_p0_notebooks()``).  Entries with ``skip=True``
         are silently excluded.  The iteration order determines row order in the
         rendered table — pass a sorted/stable list for deterministic output.
+    popular_stems:
+        Optional list of ``output.stem`` values for the "most popular"
+        notebooks. When given, they render in a short top table (in
+        ``popular_stems`` order) and the rest fold into a collapsible
+        ``<details>`` block, like the AMD Notebooks section. When ``None`` or
+        empty (default), all active notebooks render in a single flat table.
 
     Returns
     -------
@@ -85,24 +113,34 @@ def render_molab_readme_section(notebooks: Iterable["MolabNotebook"]) -> str:
     """
     active = [nb for nb in notebooks if not nb.skip]
 
-    # Build the table rows — one row per active notebook.
-    # Column layout mirrors the existing Main Notebooks table: Notebook | Open
-    rows: list[str] = []
-    for nb in active:
-        badge = _badge_markdown(nb)
-        rows.append(f"| {nb.display_name} | {badge} |")
+    popular: list["MolabNotebook"] = []
+    if popular_stems:
+        by_stem = {nb.output.stem: nb for nb in active}
+        seen: set[str] = set()
+        for stem in popular_stems:
+            nb = by_stem.get(stem)
+            if nb is not None and stem not in seen:
+                popular.append(nb)
+                seen.add(stem)
 
-    table_body = "\n".join(rows)
+    popular_set = {nb.output.stem for nb in popular}
+    rest = [nb for nb in active if nb.output.stem not in popular_set]
 
-    section = (
-        "## Open in molab\n"
+    # Nothing to split: render one flat table (avoids an empty table/details).
+    if not popular or not rest:
+        body = "\n".join(_row(nb) for nb in active)
+        return f"{_INTRO}{_TABLE_HEADER}{body}\n"
+
+    popular_body = "\n".join(_row(nb) for nb in popular)
+    rest_body = "\n".join(_row(nb) for nb in rest)
+    return (
+        f"{_INTRO}{_TABLE_HEADER}{popular_body}\n"
         "\n"
-        "Run any of these on [molab](https://molab.marimo.io), Marimo's "
-        "hosted GPU notebooks. They're reactive: change a value in one "
-        "cell, the cells below recompute on their own.\n"
+        "<details>\n"
+        "  <summary>\n"
+        "    Click for all our molab notebooks:\n"
+        "  </summary>\n"
         "\n"
-        "| Notebook | Open |\n"
-        "| --- | --- |\n"
-        f"{table_body}\n"
+        f"{_TABLE_HEADER}{rest_body}\n"
+        "</details>\n"
     )
-    return section

--- a/tests/test_molab_readme_links.py
+++ b/tests/test_molab_readme_links.py
@@ -285,6 +285,57 @@ def test_renderer_link_targets_exist_for_generated_files() -> None:
         )
 
 
+def test_renderer_popular_split() -> None:
+    """When ``popular_stems`` is provided, the renderer surfaces those notebooks
+    in a top table and folds the rest into a collapsible ``<details>`` block,
+    mirroring the AMD Notebooks section (R-readme).
+
+    Invariants:
+      - a single ``<details>`` collapsible is emitted,
+      - every popular badge appears BEFORE the ``<details>`` opens,
+      - every input notebook still appears exactly once (none dropped/duplicated),
+      - passing ``popular_stems=None`` reproduces the flat single-table output.
+    """
+    _renderer_skip_if_absent()
+    active = [nb for nb in mm.MOLAB_NOTEBOOKS if not nb.skip]
+    if len(active) < 4:
+        pytest.skip("Not enough active notebooks to exercise the popular split.")
+
+    popular = active[:3]
+    popular_stems = [nb.output.stem for nb in popular]
+    result = _README_MOD.render_molab_readme_section(
+        mm.MOLAB_NOTEBOOKS, popular_stems=popular_stems
+    )
+
+    # Exactly one collapsible, and it opens after the popular rows.
+    assert result.count("<details>") == 1 and result.count("</details>") == 1, (
+        "Expected exactly one <details> collapsible in the split rendering."
+    )
+    details_at = result.index("<details>")
+    for nb in popular:
+        url_frag = f"/molab/{nb.output.name}"
+        first = result.find(url_frag)
+        assert first != -1, f"Popular notebook {nb.output.name} missing from output."
+        assert first < details_at, (
+            f"Popular notebook {nb.output.name} must render before <details>, "
+            "not inside the collapsible."
+        )
+
+    # Every active notebook appears exactly once across both tables.
+    for nb in active:
+        url_frag = f"/molab/{nb.output.name}"
+        assert result.count(url_frag) == 1, (
+            f"{nb.output.name} should appear exactly once; "
+            f"found {result.count(url_frag)}."
+        )
+
+    # popular_stems=None is the legacy flat table (no collapsible).
+    flat = _README_MOD.render_molab_readme_section(mm.MOLAB_NOTEBOOKS)
+    assert "<details>" not in flat, (
+        "Default (popular_stems=None) must render a single flat table."
+    )
+
+
 # ---------------------------------------------------------------------------
 # AXIS 2 — committed README tests (read README.md between markers)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

The `Open in molab` README section listed every molab notebook in one flat table (137 rows). This makes it match the `AMD Notebooks` section: the most popular molab notebooks show in a short top table, and the rest fold into a collapsible `<details>` block.

## How

"Most popular" is defined the same way the AMD section defines it: the molab siblings of the hand-written `### Main Notebooks` table, in Main order, capped at 6. Siblings with no molab output (for example a vllm/GRPO notebook) are skipped, so the top list is "up to 6".

- `scripts/molab_readme.py`: `render_molab_readme_section` gains an optional `popular_stems` argument. When given, the popular notebooks render in a top table and the rest go into a `<details>` block. Default `None` keeps the original single flat table, so the function stays a pure, backwards compatible renderer.
- `scripts/molab_generate.py`: adds `_popular_molab_stems`, which parses the `### Main Notebooks` table (unquoting `%28`/`%29` so stems match), maps each entry to its molab sibling, caps at 6, and passes the result to the renderer.
- `README.md`: regenerated. Top 6 are Unsloth Studio, Gemma4 (E2B) Vision, Qwen3.5 (4B) Vision, Qwen3.5 (2B) Vision, gpt-oss (20B) Fine-tuning, gpt-oss (20B) GRPO, which is the same top-6 as the AMD section.
- `tests/test_molab_readme_links.py`: adds one renderer test for the popular split (single `<details>`, popular rows before it, every notebook present exactly once, `popular_stems=None` stays flat).

## Notes

- The README is generated, never hand edited. Regenerate with `python scripts/molab_generate.py --readme` (or the full `python update_all_notebooks.py`).
- Re-running the generator produces no further diff (idempotent).
- `python -m pytest tests/test_molab_readme_links.py` passes (15 tests).