### PR TITLE
molab: promote "Open in molab" heading to H1 to match AMD section

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,7 +716,7 @@ These notebooks target AMD ROCm GPUs and are not available in Colab. View / down
 <!-- End of Notebook Links -->
 
 <!-- MOLAB:START -->
-## 🍃 Open in molab
+# 🍃 Open in molab
 
 Run any of these on [molab](https://molab.marimo.io), Marimo's hosted GPU notebooks. They're reactive: change a value in one cell, the cells below recompute on their own.
 

--- a/scripts/molab_readme.py
+++ b/scripts/molab_readme.py
@@ -122,7 +122,7 @@ def _row(nb: "MolabNotebook") -> str:
 
 
 _INTRO = (
-    "## 🍃 Open in molab\n"
+    "# 🍃 Open in molab\n"
     "\n"
     "Run any of these on [molab](https://molab.marimo.io), Marimo's "
     "hosted GPU notebooks. They're reactive: change a value in one "


### PR DESCRIPTION
## What

The molab `Open in molab` heading was an H2 (`##`), while the AMD and Kaggle section titles are H1 (`#`), so it rendered smaller than the other notebook sections. This promotes it to H1 so the title matches their size.

One line change in the renderer (`scripts/molab_readme.py`); README regenerated. The section stays idempotent on re-run.