### PR TITLE
notebooks: shorten CodeForces label to "CodeForces CoT Reasoning"

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ Below are Colab notebooks, organized by model. You can also view all [notebooks 
 ### Other Notebooks
 | Model | Type | Notebook Link |
 | --- | --- | --- |
-| **CodeForces cot Finetune<br>for Reasoning on CodeForces**  | Reasoning | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/CodeForces-cot-Finetune_for_Reasoning_on_CodeForces.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
+| **CodeForces CoT Reasoning**  |  | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/CodeForces-cot-Finetune_for_Reasoning_on_CodeForces.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
 | **Synthetic Data Hackathon**  | Synthetic Data | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Synthetic_Data_Hackathon.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
 | **Unsloth**  | Studio | <a href="https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Unsloth_Studio.ipynb" target="_blank" rel="noopener noreferrer"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> |
 
@@ -543,7 +543,7 @@ Below are Colab notebooks, organized by model. You can also view all [notebooks 
 ### Other Notebooks
 | Model | Type | Notebook Link |
 | --- | --- | --- |
-| **CodeForces cot Finetune<br>for Reasoning on CodeForces**  | Reasoning | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-CodeForces-cot-Finetune_for_Reasoning_on_CodeForces.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
+| **CodeForces CoT Reasoning**  |  | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-CodeForces-cot-Finetune_for_Reasoning_on_CodeForces.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
 | **Unsloth**  | Studio | <a href="https://www.kaggle.com/notebooks/welcome?src=https://github.com/unslothai/notebooks/blob/main/nb/Kaggle-Unsloth_Studio.ipynb&accelerator=nvidiaTeslaT4" target="_blank" rel="noopener noreferrer"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open in Kaggle"></a> |
 
 </details>
@@ -623,7 +623,7 @@ These notebooks target AMD ROCm GPUs and are not available in Colab. View / down
 | **Qwen3 5** **(4B)** | Vision Math | [GitHub](https://github.com/unslothai/notebooks/blob/main/nb/AMD-Qwen3_5_(4B)_Vision_GRPO.ipynb) |
 | **Qwen3** **(14B)** |  | [GitHub](https://github.com/unslothai/notebooks/blob/main/nb/AMD-Qwen3_(14B).ipynb) |
 | **Qwen3** **(14B)** | Reasoning Conversational | [GitHub](https://github.com/unslothai/notebooks/blob/main/nb/AMD-Qwen3_(14B)-Reasoning-Conversational.ipynb) |
-| **CodeForces cot Finetune for Reasoning on CodeForces** | Reasoning | [GitHub](https://github.com/unslothai/notebooks/blob/main/nb/AMD-CodeForces-cot-Finetune_for_Reasoning_on_CodeForces.ipynb) |
+| **CodeForces CoT Reasoning** |  | [GitHub](https://github.com/unslothai/notebooks/blob/main/nb/AMD-CodeForces-cot-Finetune_for_Reasoning_on_CodeForces.ipynb) |
 | **Llama3.3** **(70B)** | Conversational | [GitHub](https://github.com/unslothai/notebooks/blob/main/nb/AMD-Llama3.3_(70B)_A100-Conversational.ipynb) |
 | **Synthetic Data Hackathon** | Synthetic Data | [GitHub](https://github.com/unslothai/notebooks/blob/main/nb/AMD-Synthetic_Data_Hackathon.ipynb) |
 | **Gemma3** **(4B)** |  | [GitHub](https://github.com/unslothai/notebooks/blob/main/nb/AMD-Gemma3_(4B).ipynb) |
@@ -738,7 +738,7 @@ Run any of these on [molab](https://molab.marimo.io), Marimo's hosted GPU notebo
 | --- | --- | --- |
 | **All MiniLM L6 v2** |  | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/All_MiniLM_L6_v2.py) |
 | **BGE M3** |  | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/BGE_M3.py) |
-| **CodeForces cot Finetune for Reasoning on CodeForces** | Reasoning | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/CodeForces-cot-Finetune_for_Reasoning_on_CodeForces.py) |
+| **CodeForces CoT Reasoning** |  | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/CodeForces-cot-Finetune_for_Reasoning_on_CodeForces.py) |
 | **CodeGemma** **(7B)** | Conversational | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/CodeGemma_(7B)-Conversational.py) |
 | **Deepseek OCR** **(3B)** |  | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Deepseek_OCR_(3B).py) |
 | **Deepseek OCR** **(3B)** | Eval | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Deepseek_OCR_(3B)-Eval.py) |

--- a/scripts/molab_readme.py
+++ b/scripts/molab_readme.py
@@ -87,6 +87,10 @@ def _model_type_size(stem: str) -> "tuple[str, str, str]":
     """Split a notebook stem into (model, type, size), like the Colab/AMD
     tables: type is the first matching keyword, size is the ``_(...)`` group,
     model is the remaining name."""
+    # Shorten the verbose CodeForces label (matches README_MODEL_NAME_OVERRIDES
+    # in update_all_notebooks.py); the short name carries the task, so blank Type.
+    if re.search(r"codeforces.*finetune.*reasoning.*codeforces", stem, re.IGNORECASE):
+        return "CodeForces CoT Reasoning", "", ""
     s = stem.replace("-", "_")  # standardize separators before parsing
     if "A100" in s:
         s = s.replace("_A100", "")

--- a/tests/test_molab_readme_links.py
+++ b/tests/test_molab_readme_links.py
@@ -353,6 +353,8 @@ def test_renderer_model_type_columns() -> None:
         "Gemma3N_(4B)-Conversational": ("Gemma3N", "Multimodal", "4B"),  # TYPE_MAPPING remap
         "Unsloth_Studio": ("Unsloth", "Studio", ""),
         "Whisper": ("Whisper", "", ""),
+        # Verbose label is shortened and Type blanked (matches update_all_notebooks.py).
+        "CodeForces-cot-Finetune_for_Reasoning_on_CodeForces": ("CodeForces CoT Reasoning", "", ""),
     }
     for stem, expected in cases.items():
         assert _README_MOD._model_type_size(stem) == expected, (

--- a/update_all_notebooks.py
+++ b/update_all_notebooks.py
@@ -1118,13 +1118,24 @@ README_SKIP_NOTEBOOKS = [
 # Per-notebook overrides for the Model column in README.md tables. Keyed by
 # the on-disk basename (with .ipynb). The value is the literal Markdown text
 # rendered between the surrounding ** ** bold markers, so HTML tags such as
-# <br> can be embedded for multi-line cells. Only set this for notebooks
-# whose computed model name is too long to fit on a single README row.
+# <br> can be embedded for multi-line cells. Set this for notebooks whose
+# computed model name is too long to fit on a single README row.
 README_MODEL_NAME_OVERRIDES = {
     "CodeForces-cot-Finetune_for_Reasoning_on_CodeForces.ipynb":
-        "CodeForces cot Finetune<br>for Reasoning on CodeForces",
+        "CodeForces CoT Reasoning",
     "Kaggle-CodeForces-cot-Finetune_for_Reasoning_on_CodeForces.ipynb":
-        "CodeForces cot Finetune<br>for Reasoning on CodeForces",
+        "CodeForces CoT Reasoning",
+    "AMD-CodeForces-cot-Finetune_for_Reasoning_on_CodeForces.ipynb":
+        "CodeForces CoT Reasoning",
+}
+
+# Per-notebook overrides for the Type column, keyed by on-disk basename.
+# Blank where the shortened Model name already carries the task, so the row
+# does not repeat it.
+README_TYPE_OVERRIDES = {
+    "CodeForces-cot-Finetune_for_Reasoning_on_CodeForces.ipynb": "",
+    "Kaggle-CodeForces-cot-Finetune_for_Reasoning_on_CodeForces.ipynb": "",
+    "AMD-CodeForces-cot-Finetune_for_Reasoning_on_CodeForces.ipynb": "",
 }
 
 
@@ -4830,6 +4841,9 @@ def update_readme(
         # clean.
         if is_grpo_trainer and notebook_uses_fast_inference(path):
             model_type = (model_type or "GRPO") + " + vLLM"
+        # Per-notebook Type override (after RL classification) keyed by basename.
+        if on_disk_basename in README_TYPE_OVERRIDES:
+            model_type = README_TYPE_OVERRIDES[on_disk_basename]
         architecture = info['architecture'] if info else None
         size = info['size']
         size = size.replace(r"_", " ") if size else None


### PR DESCRIPTION
## What

The CodeForces reasoning notebook rendered as **CodeForces cot Finetune for Reasoning on CodeForces**, which took up too much horizontal space in the README tables. This shortens it to **CodeForces CoT Reasoning** with a blank Type cell (the short name already carries the task), across all four tables it appears in: Colab, Kaggle, AMD, and molab.

Before:

| Model | Type |
| --- | --- |
| CodeForces cot Finetune for Reasoning on CodeForces | Reasoning |

After:

| Model | Type |
| --- | --- |
| CodeForces CoT Reasoning |  |

## How

- `update_all_notebooks.py`: point `README_MODEL_NAME_OVERRIDES` at the short name for the Colab, Kaggle, and AMD basenames, and add a `README_TYPE_OVERRIDES` map (applied after RL classification) to blank the Type for those rows.
- `scripts/molab_readme.py`: return the same short label and blank Type for the molab table.
- `README.md`: the four rows updated to match the generator output.

## Notes

- Only the displayed label changes. The notebook filenames and links are untouched.
- molab section regenerates idempotently; `pytest tests/test_molab_readme_links.py tests/test_molab_manifest.py` passes (162 tests), including a new case asserting the shortened label.