### PR TITLE
Remove Known Issues / Environment Notes section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -866,14 +866,6 @@ Run any of these on [molab](https://molab.marimo.io), Marimo's hosted GPU notebo
 </details>
 <!-- MOLAB:END -->
 
-## Known Issues / Environment Notes
-
-- **NumPy 2.x ↔ soxr**: NumPy 2.x breaks soxr, causing Unsloth import failures. Pin `numpy<2` to resolve. Use `pip install --force-reinstall "numpy<2"` if needed. _Impact: Prevents Unsloth from running._
-- **soxr reinstall**: `pip install --force-reinstall soxr` can pull NumPy 2.x back unless using `--no-deps`. Use `pip install --force-reinstall --no-deps soxr` to avoid this. _Impact: May reintroduce NumPy 2.x and break Unsloth imports._
-- **typing_extensions**: Older typing_extensions can break torch import (TypeIs missing) until upgraded. Upgrade with `pip install --upgrade typing_extensions`. _Impact: Prevents PyTorch from importing correctly._
-- **Resolver warnings**: Pinning `numpy<2` can cause pip resolver warnings with SciPy/Numba; typically non-fatal. _Impact: Cosmetic warnings only, does not affect functionality._
-- **ROCm / triton_key**: LoRA backward can crash under `torch.compile` if Triton lacks `triton_key`; workaround is to disable Inductor/compile on ROCm (handled in code now, but worth noting). _Impact: May cause training crashes on AMD GPUs when using torch.compile._
-
 # ✨ Contributing to Notebooks
 
 If you'd like to contribute to our notebooks, here's a guide to get you started:


### PR DESCRIPTION
Removes the `Known Issues / Environment Notes` section from the README.

The section listed a handful of environment workarounds (NumPy 2.x vs soxr, soxr reinstall, typing_extensions, pip resolver warnings, ROCm triton_key). These are no longer needed in the README: the relevant cases are handled in code, and the rest are transient environment notes that do not belong in the top-level notebook index.

Scope: documentation only. The section sits outside the auto-generated `<!-- MOLAB:START/END -->` block and is not produced by `update_all_notebooks.py`, so nothing regenerates it. `tests/test_molab_readme_links.py` still passes.