### PR TITLE
Label Unsloth Studio as Chat UI in AMD and Molab tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,7 +553,7 @@ These notebooks target AMD ROCm GPUs and are not available in Colab. View / down
 
 | Model | Type | Notebook |
 | --- | --- | --- |
-| **Unsloth** | Studio | [GitHub](https://github.com/unslothai/notebooks/blob/main/nb/AMD-Unsloth_Studio.ipynb) |
+| **Unsloth Studio** | Chat UI | [GitHub](https://github.com/unslothai/notebooks/blob/main/nb/AMD-Unsloth_Studio.ipynb) |
 | **Gemma4** **(E2B)** | Vision | [GitHub](https://github.com/unslothai/notebooks/blob/main/nb/AMD-Gemma4_(E2B)-Vision.ipynb) |
 | **Qwen3 5** **(4B)** | Vision | [GitHub](https://github.com/unslothai/notebooks/blob/main/nb/AMD-Qwen3_5_(4B)_Vision.ipynb) |
 | **Qwen3 5** **(2B)** | Vision | [GitHub](https://github.com/unslothai/notebooks/blob/main/nb/AMD-Qwen3_5_(2B)_Vision.ipynb) |
@@ -722,7 +722,7 @@ Run any of these on [molab](https://molab.marimo.io), Marimo's hosted GPU notebo
 
 | Model | Type | Notebook |
 | --- | --- | --- |
-| **Unsloth** | Studio | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Unsloth_Studio.py) |
+| **Unsloth Studio** | Chat UI | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Unsloth_Studio.py) |
 | **Gemma4** **(E2B)** | Vision | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Gemma4_(E2B)-Vision.py) |
 | **Qwen3 5** **(4B)** | Vision | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Qwen3_5_(4B)_Vision.py) |
 | **Qwen3 5** **(2B)** | Vision | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Qwen3_5_(2B)_Vision.py) |

--- a/scripts/molab_readme.py
+++ b/scripts/molab_readme.py
@@ -136,6 +136,7 @@ _MODEL_TYPE_SIZE_OVERRIDES = {
     'Qwen_3_5_27B_A100(80GB)': ('Qwen 3 5 27B(80GB)', 'Conversational', ''),
     'Spark_TTS_(0_5B)': ('Spark TTS', 'TTS', '0.5B'),
     'TinyQwen3_MoE': ('TinyQwen3 MoE', 'MoE', ''),
+    'Unsloth_Studio': ('Unsloth Studio', 'Chat UI', ''),
     'Whisper': ('Whisper', 'Fine Tuning', 'Large'),
     'bert_classification': ('ModernBERT', 'Classification', 'Large'),
     'gpt-oss-(20B)-GRPO': ('gpt oss', 'Auto Kernel Creation', '20B'),

--- a/tests/test_molab_readme_links.py
+++ b/tests/test_molab_readme_links.py
@@ -351,7 +351,7 @@ def test_renderer_model_type_columns() -> None:
         "gpt-oss-(20B)-Fine-tuning": ("gpt oss", "Fine Tuning", "20B"),
         "Qwen3_(14B)-Reasoning-Conversational": ("Qwen3", "Reasoning Conversational", "14B"),
         "Gemma3N_(4B)-Conversational": ("Gemma3N", "Multimodal", "4B"),  # TYPE_MAPPING remap
-        "Unsloth_Studio": ("Unsloth", "Studio", ""),
+        "Unsloth_Studio": ("Unsloth Studio", "Chat UI", ""),
         # FIRST_MAPPING remaps Whisper.ipynb -> Whisper_(Large)-Fine-Tuning, so the
         # molab row matches the Colab/AMD tables (Fine Tuning, Large) not a blank.
         "Whisper": ("Whisper", "Fine Tuning", "Large"),

--- a/update_all_notebooks.py
+++ b/update_all_notebooks.py
@@ -1156,6 +1156,13 @@ README_TYPE_OVERRIDES = {
     "LFM2.5_(1.2B)-Translation.ipynb": "Translation",
 }
 
+# Per-notebook (Model, Type) overrides that apply ONLY to the AMD Notebooks
+# section, keyed by the prefix-stripped basename. Colab/Kaggle keep the shared
+# overrides above and the filename-derived name/type.
+README_AMD_NAME_TYPE_OVERRIDES = {
+    "Unsloth_Studio.ipynb": ("Unsloth Studio", "Chat UI"),
+}
+
 
 FIRST_MAPPING_NAME = {
     "gpt-oss-(20B)-Fine-tuning.ipynb" : "gpt_oss_(20B)-Fine-tuning.ipynb",
@@ -4961,6 +4968,10 @@ def update_readme(
         # are routed to a dedicated "AMD Notebooks" section at the very end
         # of the README with bare GitHub links (no Colab badge).
         is_amd_notebook = os.path.basename(path).startswith("AMD-")
+
+        # AMD-only Model/Type override (Colab/Kaggle keep their own labels).
+        if is_amd_notebook and bare_basename in README_AMD_NAME_TYPE_OVERRIDES:
+            model_name, model_type = README_AMD_NAME_TYPE_OVERRIDES[bare_basename]
 
         notebook_data.append(
             {


### PR DESCRIPTION
Relabels the Unsloth Studio notebook in the AMD and Molab README tables from `Unsloth | Studio` to `Unsloth Studio | Chat UI`, matching the hand-written Main Notebooks table.

The filename parser splits `Unsloth_Studio` into model `Unsloth` + type `Studio`. Since the Model/Type overrides are shared across Colab/Kaggle/AMD, the change is scoped so only AMD and Molab are affected; Colab and Kaggle keep their current labels.

Changes:
- `update_all_notebooks.py`: add `README_AMD_NAME_TYPE_OVERRIDES` and apply it for AMD rows in `update_readme`.
- `scripts/molab_readme.py`: add an `Unsloth_Studio` entry to `_MODEL_TYPE_SIZE_OVERRIDES`.
- `README.md`: the two regenerated rows (AMD + Molab).
- `tests/test_molab_readme_links.py`: update the pinned molab renderer expectation.

Verified locally: ruff narrow gate clean, and the molab static suite (readme links, generation parity, no-colab markers, marimo validity) passes.