### PR TITLE
Switch dataset to Etherll/kaira and rename Elise

### DIFF
--- a/molab/Llasa_TTS_(1B).py
+++ b/molab/Llasa_TTS_(1B).py
@@ -168,7 +168,7 @@ def _(mo):
     <a name="Data"></a>
     ### Data Prep
 
-    We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format:
+    We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format:
     **text, audio**. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
     """)
     return
@@ -178,7 +178,7 @@ def _(mo):
 def _():
     from datasets import load_dataset
 
-    dataset = load_dataset("MrDragonFox/Elise", split="train")
+    dataset = load_dataset("Etherll/kaira", split="train")
     OUTPUT_DIR = "processed_data_memmap"
     return OUTPUT_DIR, dataset
 
@@ -604,7 +604,7 @@ def _(mo):
 
 @app.cell
 def _():
-    input_text = "Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person."
+    input_text = "Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person."
     return (input_text,)
 
 

--- a/molab/Llasa_TTS_(3B).py
+++ b/molab/Llasa_TTS_(3B).py
@@ -168,7 +168,7 @@ def _(mo):
     <a name="Data"></a>
     ### Data Prep
 
-    We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format:
+    We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format:
     **text, audio**. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
     """)
     return
@@ -178,7 +178,7 @@ def _(mo):
 def _():
     from datasets import load_dataset
 
-    dataset = load_dataset("MrDragonFox/Elise", split="train")
+    dataset = load_dataset("Etherll/kaira", split="train")
     OUTPUT_DIR = "processed_data_memmap"
     return OUTPUT_DIR, dataset
 
@@ -604,7 +604,7 @@ def _(mo):
 
 @app.cell
 def _():
-    input_text = "Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person."
+    input_text = "Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person."
     return (input_text,)
 
 

--- a/molab/Orpheus_(3B)-TTS.py
+++ b/molab/Orpheus_(3B)-TTS.py
@@ -170,7 +170,7 @@ def _(mo):
     <a name="Data"></a>
     ### Data Prep
 
-    We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
+    We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
     """)
     return
 
@@ -179,7 +179,7 @@ def _(mo):
 def _():
     from datasets import load_dataset
 
-    dataset = load_dataset("MrDragonFox/Elise", split="train")
+    dataset = load_dataset("Etherll/kaira", split="train")
     return (dataset,)
 
 
@@ -384,7 +384,7 @@ def _(mo):
 @app.cell
 def _():
     prompts = [
-        "Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person.",
+        "Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person.",
     ]
 
     chosen_voice = None  # None for single-speaker

--- a/molab/Oute_TTS_(1B).py
+++ b/molab/Oute_TTS_(1B).py
@@ -193,7 +193,7 @@ def _(mo):
     <a name="Data"></a>
     ### Data Prep
 
-    We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio**, but maintaining the correct structure is essential for optimal training.
+    We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio**, but maintaining the correct structure is essential for optimal training.
     """)
     return
 
@@ -202,7 +202,7 @@ def _(mo):
 def _():
     from datasets import load_dataset, Audio, Dataset
 
-    dataset = load_dataset("MrDragonFox/Elise", split="train")
+    dataset = load_dataset("Etherll/kaira", split="train")
     dataset = dataset.cast_column("audio", Audio(sampling_rate=24000))
     return Audio, Dataset, dataset
 
@@ -482,7 +482,7 @@ def _(mo):
 
 @app.cell
 def _():
-    input_text = "Hey there my name is Elise, and I'm a speech generation model that can sound like a person."
+    input_text = "Hey there my name is Kaira, and I'm a speech generation model that can sound like a person."
     return (input_text,)
 
 

--- a/molab/Sesame_CSM_(1B)-TTS.py
+++ b/molab/Sesame_CSM_(1B)-TTS.py
@@ -152,7 +152,7 @@ def _(mo):
     <a name="Data"></a>
     ### Data Prep
 
-    We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
+    We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
     """)
     return
 
@@ -165,7 +165,7 @@ def _(torch):
     from transformers import AutoProcessor
 
     processor_1 = AutoProcessor.from_pretrained("unsloth/csm-1b")
-    raw_ds = load_dataset("MrDragonFox/Elise", split="train")
+    raw_ds = load_dataset("Etherll/kaira", split="train")
     speaker_key = "source"
     if "source" not in raw_ds.column_names and "speaker_id" not in raw_ds.column_names:
         # Getting the speaker id is important for multi-speaker models and speaker consistency

--- a/molab/Spark_TTS_(0_5B).py
+++ b/molab/Spark_TTS_(0_5B).py
@@ -186,7 +186,7 @@ def _(mo):
     <a name="Data"></a>
     ### Data Prep
 
-    We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
+    We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
     """)
     return
 
@@ -195,7 +195,7 @@ def _(mo):
 def _():
     from datasets import load_dataset
 
-    dataset = load_dataset("MrDragonFox/Elise", split="train")
+    dataset = load_dataset("Etherll/kaira", split="train")
     return (dataset,)
 
 
@@ -398,7 +398,7 @@ def _(mo):
 
 @app.cell
 def _():
-    input_text = "Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person."
+    input_text = "Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person."
 
     chosen_voice = None  # None for single-speaker
     return chosen_voice, input_text

--- a/molab/Whisper.py
+++ b/molab/Whisper.py
@@ -157,7 +157,7 @@ def _(mo):
     <a name="Data"></a>
     ### Data Prep
 
-    We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio**. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
+    We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio**. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
     """)
     return
 
@@ -187,7 +187,7 @@ def _(model_1, tokenizer):
 
     from datasets import load_dataset, Audio
 
-    dataset = load_dataset("MrDragonFox/Elise", split="train")
+    dataset = load_dataset("Etherll/kaira", split="train")
     dataset = dataset.cast_column("audio", Audio(sampling_rate=16000))
     dataset = dataset.train_test_split(test_size=0.06)
     train_dataset = [

--- a/nb/AMD-Llasa_TTS_(1B).ipynb
+++ b/nb/AMD-Llasa_TTS_(1B).ipynb
@@ -234,7 +234,7 @@
     "<a name=\"Data\"></a>\n",
     "### Data Prep  \n",
     "\n",
-    "We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format:\n",
+    "We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format:\n",
     "**text, audio**. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
    ]
   },
@@ -247,7 +247,7 @@
    "outputs": [],
    "source": [
     "from datasets import load_dataset\n",
-    "dataset = load_dataset(\"MrDragonFox/Elise\", split = \"train\")\n",
+    "dataset = load_dataset(\"Etherll/kaira\", split = \"train\")\n",
     "OUTPUT_DIR = 'processed_data_memmap'"
    ]
   },
@@ -1330,7 +1330,7 @@
    },
    "outputs": [],
    "source": [
-    "input_text = \"Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person.\""
+    "input_text = \"Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person.\""
    ]
   },
   {

--- a/nb/AMD-Llasa_TTS_(3B).ipynb
+++ b/nb/AMD-Llasa_TTS_(3B).ipynb
@@ -226,7 +226,7 @@
     "<a name=\"Data\"></a>\n",
     "### Data Prep  \n",
     "\n",
-    "We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format:\n",
+    "We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format:\n",
     "**text, audio**. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
    ]
   },
@@ -239,7 +239,7 @@
    "outputs": [],
    "source": [
     "from datasets import load_dataset\n",
-    "dataset = load_dataset(\"MrDragonFox/Elise\", split = \"train\")\n",
+    "dataset = load_dataset(\"Etherll/kaira\", split = \"train\")\n",
     "OUTPUT_DIR = 'processed_data_memmap'"
    ]
   },
@@ -1322,7 +1322,7 @@
    },
    "outputs": [],
    "source": [
-    "input_text = \"Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person.\""
+    "input_text = \"Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person.\""
    ]
   },
   {

--- a/nb/AMD-Orpheus_(3B)-TTS.ipynb
+++ b/nb/AMD-Orpheus_(3B)-TTS.ipynb
@@ -188,7 +188,7 @@
     "<a name=\"Data\"></a>\n",
     "### Data Prep  \n",
     "\n",
-    "We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
+    "We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
    ]
   },
   {
@@ -208,7 +208,7 @@
    "outputs": [],
    "source": [
     "from datasets import load_dataset\n",
-    "dataset = load_dataset(\"MrDragonFox/Elise\", split = \"train\")"
+    "dataset = load_dataset(\"Etherll/kaira\", split = \"train\")"
    ]
   },
   {
@@ -1892,7 +1892,7 @@
    "outputs": [],
    "source": [
     "prompts = [\n",
-    "    \"Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person.\",\n",
+    "    \"Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person.\",\n",
     "]\n",
     "\n",
     "chosen_voice = None # None for single-speaker"
@@ -1923,10 +1923,10 @@
      "output_type": "display_data",
      "data": {
       "text/plain": [
-       "Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person.\n"
+       "Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person.\n"
       ],
       "text/html": [
-       "<pre>Hey there my name is Elise, &lt;giggles&gt; and I&#x27;m a speech generation model that can sound like a person.\n",
+       "<pre>Hey there my name is Kaira, &lt;giggle&gt; and I&#x27;m a speech generation model that can sound like a person.\n",
        "</pre>"
       ]
      },

--- a/nb/AMD-Oute_TTS_(1B).ipynb
+++ b/nb/AMD-Oute_TTS_(1B).ipynb
@@ -188,7 +188,7 @@
     "<a name=\"Data\"></a>\n",
     "### Data Prep  \n",
     "\n",
-    "We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio**, but maintaining the correct structure is essential for optimal training."
+    "We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio**, but maintaining the correct structure is essential for optimal training."
    ]
   },
   {
@@ -200,7 +200,7 @@
    "outputs": [],
    "source": [
     "from datasets import load_dataset,Audio,Dataset\n",
-    "dataset = load_dataset(\"MrDragonFox/Elise\", split = \"train\")\n",
+    "dataset = load_dataset(\"Etherll/kaira\", split = \"train\")\n",
     "dataset = dataset.cast_column(\"audio\", Audio(sampling_rate = 24000))"
    ]
   },
@@ -4323,7 +4323,7 @@
    },
    "outputs": [],
    "source": [
-    "input_text = \"Hey there my name is Elise, and I'm a speech generation model that can sound like a person.\""
+    "input_text = \"Hey there my name is Kaira, and I'm a speech generation model that can sound like a person.\""
    ]
   },
   {

--- a/nb/AMD-Sesame_CSM_(1B)-TTS.ipynb
+++ b/nb/AMD-Sesame_CSM_(1B)-TTS.ipynb
@@ -169,7 +169,7 @@
     "<a name=\"Data\"></a>\n",
     "### Data Prep  \n",
     "\n",
-    "We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
+    "We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
    ]
   },
   {
@@ -187,7 +187,7 @@
     "from transformers import AutoProcessor\n",
     "processor = AutoProcessor.from_pretrained(\"unsloth/csm-1b\")\n",
     "\n",
-    "raw_ds = load_dataset(\"MrDragonFox/Elise\", split = \"train\")\n",
+    "raw_ds = load_dataset(\"Etherll/kaira\", split = \"train\")\n",
     "\n",
     "# Getting the speaker id is important for multi-speaker models and speaker consistency\n",
     "speaker_key = \"source\"\n",

--- a/nb/AMD-Spark_TTS_(0_5B).ipynb
+++ b/nb/AMD-Spark_TTS_(0_5B).ipynb
@@ -209,7 +209,7 @@
     "<a name=\"Data\"></a>\n",
     "### Data Prep  \n",
     "\n",
-    "We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
+    "We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
    ]
   },
   {
@@ -229,7 +229,7 @@
    "outputs": [],
    "source": [
     "from datasets import load_dataset\n",
-    "dataset = load_dataset(\"MrDragonFox/Elise\", split = \"train\")"
+    "dataset = load_dataset(\"Etherll/kaira\", split = \"train\")"
    ]
   },
   {
@@ -1238,7 +1238,7 @@
    },
    "outputs": [],
    "source": [
-    "input_text = \"Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person.\"\n",
+    "input_text = \"Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person.\"\n",
     "\n",
     "chosen_voice = None # None for single-speaker"
    ]
@@ -1268,7 +1268,7 @@
      "output_type": "display_data",
      "data": {
       "text/plain": [
-       "Generating speech for: 'Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person.'\n",
+       "Generating speech for: 'Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person.'\n",
        "Generating token sequence...\n",
        "Token sequence generated.\n",
        "Found 348 semantic tokens.\n",
@@ -1278,7 +1278,7 @@
        "Audio saved to generated_speech_controllable.wav\n"
       ],
       "text/html": [
-       "<pre>Generating speech for: &#x27;Hey there my name is Elise, &lt;giggles&gt; and I&#x27;m a speech generation model that can sound like a person.&#x27;\n",
+       "<pre>Generating speech for: &#x27;Hey there my name is Kaira, &lt;giggle&gt; and I&#x27;m a speech generation model that can sound like a person.&#x27;\n",
        "Generating token sequence...\n",
        "Token sequence generated.\n",
        "Found 348 semantic tokens.\n",

--- a/nb/AMD-Whisper.ipynb
+++ b/nb/AMD-Whisper.ipynb
@@ -422,7 +422,7 @@
         "<a name=\"Data\"></a>\n",
         "### Data Prep  \n",
         "\n",
-        "We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio**. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
+        "We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio**. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
       ]
     },
     {
@@ -545,7 +545,7 @@
         "        \"labels\": tokenized_text.input_ids,\n",
         "    }\n",
         "from datasets import load_dataset, Audio\n",
-        "dataset = load_dataset(\"MrDragonFox/Elise\", split = \"train\")\n",
+        "dataset = load_dataset(\"Etherll/kaira\", split = \"train\")\n",
         "\n",
         "dataset = dataset.cast_column(\"audio\", Audio(sampling_rate = 16000))\n",
         "dataset = dataset.train_test_split(test_size = 0.06)\n",

--- a/nb/Kaggle-Llasa_TTS_(1B).ipynb
+++ b/nb/Kaggle-Llasa_TTS_(1B).ipynb
@@ -227,7 +227,7 @@
     "<a name=\"Data\"></a>\n",
     "### Data Prep  \n",
     "\n",
-    "We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format:\n",
+    "We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format:\n",
     "**text, audio**. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
    ]
   },
@@ -240,7 +240,7 @@
    "outputs": [],
    "source": [
     "from datasets import load_dataset\n",
-    "dataset = load_dataset(\"MrDragonFox/Elise\", split = \"train\")\n",
+    "dataset = load_dataset(\"Etherll/kaira\", split = \"train\")\n",
     "OUTPUT_DIR = 'processed_data_memmap'"
    ]
   },
@@ -1323,7 +1323,7 @@
    },
    "outputs": [],
    "source": [
-    "input_text = \"Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person.\""
+    "input_text = \"Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person.\""
    ]
   },
   {

--- a/nb/Kaggle-Llasa_TTS_(3B).ipynb
+++ b/nb/Kaggle-Llasa_TTS_(3B).ipynb
@@ -219,7 +219,7 @@
     "<a name=\"Data\"></a>\n",
     "### Data Prep  \n",
     "\n",
-    "We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format:\n",
+    "We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format:\n",
     "**text, audio**. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
    ]
   },
@@ -232,7 +232,7 @@
    "outputs": [],
    "source": [
     "from datasets import load_dataset\n",
-    "dataset = load_dataset(\"MrDragonFox/Elise\", split = \"train\")\n",
+    "dataset = load_dataset(\"Etherll/kaira\", split = \"train\")\n",
     "OUTPUT_DIR = 'processed_data_memmap'"
    ]
   },
@@ -1315,7 +1315,7 @@
    },
    "outputs": [],
    "source": [
-    "input_text = \"Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person.\""
+    "input_text = \"Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person.\""
    ]
   },
   {

--- a/nb/Kaggle-Orpheus_(3B)-TTS.ipynb
+++ b/nb/Kaggle-Orpheus_(3B)-TTS.ipynb
@@ -181,7 +181,7 @@
     "<a name=\"Data\"></a>\n",
     "### Data Prep  \n",
     "\n",
-    "We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
+    "We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
    ]
   },
   {
@@ -201,7 +201,7 @@
    "outputs": [],
    "source": [
     "from datasets import load_dataset\n",
-    "dataset = load_dataset(\"MrDragonFox/Elise\", split = \"train\")"
+    "dataset = load_dataset(\"Etherll/kaira\", split = \"train\")"
    ]
   },
   {
@@ -1884,7 +1884,7 @@
    "outputs": [],
    "source": [
     "prompts = [\n",
-    "    \"Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person.\",\n",
+    "    \"Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person.\",\n",
     "]\n",
     "\n",
     "chosen_voice = None # None for single-speaker"
@@ -1915,10 +1915,10 @@
      "output_type": "display_data",
      "data": {
       "text/plain": [
-       "Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person."
+       "Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person."
       ],
       "text/html": [
-       "<pre>Hey there my name is Elise, &lt;giggles&gt; and I&#x27;m a speech generation model that can sound like a person.</pre>"
+       "<pre>Hey there my name is Kaira, &lt;giggle&gt; and I&#x27;m a speech generation model that can sound like a person.</pre>"
       ]
      },
      "metadata": {}

--- a/nb/Kaggle-Oute_TTS_(1B).ipynb
+++ b/nb/Kaggle-Oute_TTS_(1B).ipynb
@@ -199,7 +199,7 @@
     "<a name=\"Data\"></a>\n",
     "### Data Prep  \n",
     "\n",
-    "We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio**, but maintaining the correct structure is essential for optimal training."
+    "We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio**, but maintaining the correct structure is essential for optimal training."
    ]
   },
   {
@@ -211,7 +211,7 @@
    "outputs": [],
    "source": [
     "from datasets import load_dataset,Audio,Dataset\n",
-    "dataset = load_dataset(\"MrDragonFox/Elise\", split = \"train\")\n",
+    "dataset = load_dataset(\"Etherll/kaira\", split = \"train\")\n",
     "dataset = dataset.cast_column(\"audio\", Audio(sampling_rate = 24000))"
    ]
   },
@@ -4334,7 +4334,7 @@
    },
    "outputs": [],
    "source": [
-    "input_text = \"Hey there my name is Elise, and I'm a speech generation model that can sound like a person.\""
+    "input_text = \"Hey there my name is Kaira, and I'm a speech generation model that can sound like a person.\""
    ]
   },
   {

--- a/nb/Kaggle-Sesame_CSM_(1B)-TTS.ipynb
+++ b/nb/Kaggle-Sesame_CSM_(1B)-TTS.ipynb
@@ -162,7 +162,7 @@
     "<a name=\"Data\"></a>\n",
     "### Data Prep  \n",
     "\n",
-    "We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
+    "We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
    ]
   },
   {
@@ -180,7 +180,7 @@
     "from transformers import AutoProcessor\n",
     "processor = AutoProcessor.from_pretrained(\"unsloth/csm-1b\")\n",
     "\n",
-    "raw_ds = load_dataset(\"MrDragonFox/Elise\", split = \"train\")\n",
+    "raw_ds = load_dataset(\"Etherll/kaira\", split = \"train\")\n",
     "\n",
     "# Getting the speaker id is important for multi-speaker models and speaker consistency\n",
     "speaker_key = \"source\"\n",

--- a/nb/Kaggle-Spark_TTS_(0_5B).ipynb
+++ b/nb/Kaggle-Spark_TTS_(0_5B).ipynb
@@ -202,7 +202,7 @@
     "<a name=\"Data\"></a>\n",
     "### Data Prep  \n",
     "\n",
-    "We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
+    "We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
    ]
   },
   {
@@ -222,7 +222,7 @@
    "outputs": [],
    "source": [
     "from datasets import load_dataset\n",
-    "dataset = load_dataset(\"MrDragonFox/Elise\", split = \"train\")"
+    "dataset = load_dataset(\"Etherll/kaira\", split = \"train\")"
    ]
   },
   {
@@ -1231,7 +1231,7 @@
    },
    "outputs": [],
    "source": [
-    "input_text = \"Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person.\"\n",
+    "input_text = \"Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person.\"\n",
     "\n",
     "chosen_voice = None # None for single-speaker"
    ]
@@ -1261,7 +1261,7 @@
      "output_type": "display_data",
      "data": {
       "text/plain": [
-       "Generating speech for: 'Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person.'\n",
+       "Generating speech for: 'Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person.'\n",
        "Generating token sequence...\n",
        "Token sequence generated.\n",
        "Found 348 semantic tokens.\n",
@@ -1271,7 +1271,7 @@
        "Audio saved to generated_speech_controllable.wav"
       ],
       "text/html": [
-       "<pre>Generating speech for: &#x27;Hey there my name is Elise, &lt;giggles&gt; and I&#x27;m a speech generation model that can sound like a person.&#x27;\n",
+       "<pre>Generating speech for: &#x27;Hey there my name is Kaira, &lt;giggle&gt; and I&#x27;m a speech generation model that can sound like a person.&#x27;\n",
        "Generating token sequence...\n",
        "Token sequence generated.\n",
        "Found 348 semantic tokens.\n",

--- a/nb/Kaggle-Whisper.ipynb
+++ b/nb/Kaggle-Whisper.ipynb
@@ -415,7 +415,7 @@
     "<a name=\"Data\"></a>\n",
     "### Data Prep  \n",
     "\n",
-    "We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio**. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
+    "We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio**. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
    ]
   },
   {
@@ -538,7 +538,7 @@
     "        \"labels\": tokenized_text.input_ids,\n",
     "    }\n",
     "from datasets import load_dataset, Audio\n",
-    "dataset = load_dataset(\"MrDragonFox/Elise\", split = \"train\")\n",
+    "dataset = load_dataset(\"Etherll/kaira\", split = \"train\")\n",
     "\n",
     "dataset = dataset.cast_column(\"audio\", Audio(sampling_rate = 16000))\n",
     "dataset = dataset.train_test_split(test_size = 0.06)\n",

--- a/nb/Llasa_TTS_(1B).ipynb
+++ b/nb/Llasa_TTS_(1B).ipynb
@@ -227,7 +227,7 @@
     "<a name=\"Data\"></a>\n",
     "### Data Prep  \n",
     "\n",
-    "We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format:\n",
+    "We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format:\n",
     "**text, audio**. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
    ]
   },
@@ -240,7 +240,7 @@
    "outputs": [],
    "source": [
     "from datasets import load_dataset\n",
-    "dataset = load_dataset(\"MrDragonFox/Elise\", split = \"train\")\n",
+    "dataset = load_dataset(\"Etherll/kaira\", split = \"train\")\n",
     "OUTPUT_DIR = 'processed_data_memmap'"
    ]
   },
@@ -1323,7 +1323,7 @@
    },
    "outputs": [],
    "source": [
-    "input_text = \"Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person.\""
+    "input_text = \"Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person.\""
    ]
   },
   {

--- a/nb/Llasa_TTS_(3B).ipynb
+++ b/nb/Llasa_TTS_(3B).ipynb
@@ -219,7 +219,7 @@
     "<a name=\"Data\"></a>\n",
     "### Data Prep  \n",
     "\n",
-    "We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format:\n",
+    "We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format:\n",
     "**text, audio**. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
    ]
   },
@@ -232,7 +232,7 @@
    "outputs": [],
    "source": [
     "from datasets import load_dataset\n",
-    "dataset = load_dataset(\"MrDragonFox/Elise\", split = \"train\")\n",
+    "dataset = load_dataset(\"Etherll/kaira\", split = \"train\")\n",
     "OUTPUT_DIR = 'processed_data_memmap'"
    ]
   },
@@ -1315,7 +1315,7 @@
    },
    "outputs": [],
    "source": [
-    "input_text = \"Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person.\""
+    "input_text = \"Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person.\""
    ]
   },
   {

--- a/nb/Orpheus_(3B)-TTS.ipynb
+++ b/nb/Orpheus_(3B)-TTS.ipynb
@@ -181,7 +181,7 @@
     "<a name=\"Data\"></a>\n",
     "### Data Prep  \n",
     "\n",
-    "We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
+    "We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
    ]
   },
   {
@@ -201,7 +201,7 @@
    "outputs": [],
    "source": [
     "from datasets import load_dataset\n",
-    "dataset = load_dataset(\"MrDragonFox/Elise\", split = \"train\")"
+    "dataset = load_dataset(\"Etherll/kaira\", split = \"train\")"
    ]
   },
   {
@@ -1884,7 +1884,7 @@
    "outputs": [],
    "source": [
     "prompts = [\n",
-    "    \"Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person.\",\n",
+    "    \"Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person.\",\n",
     "]\n",
     "\n",
     "chosen_voice = None # None for single-speaker"
@@ -1915,10 +1915,10 @@
      "output_type": "display_data",
      "data": {
       "text/plain": [
-       "Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person."
+       "Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person."
       ],
       "text/html": [
-       "<pre>Hey there my name is Elise, &lt;giggles&gt; and I&#x27;m a speech generation model that can sound like a person.</pre>"
+       "<pre>Hey there my name is Kaira, &lt;giggle&gt; and I&#x27;m a speech generation model that can sound like a person.</pre>"
       ]
      },
      "metadata": {}

--- a/nb/Oute_TTS_(1B).ipynb
+++ b/nb/Oute_TTS_(1B).ipynb
@@ -199,7 +199,7 @@
     "<a name=\"Data\"></a>\n",
     "### Data Prep  \n",
     "\n",
-    "We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio**, but maintaining the correct structure is essential for optimal training."
+    "We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio**, but maintaining the correct structure is essential for optimal training."
    ]
   },
   {
@@ -211,7 +211,7 @@
    "outputs": [],
    "source": [
     "from datasets import load_dataset,Audio,Dataset\n",
-    "dataset = load_dataset(\"MrDragonFox/Elise\", split = \"train\")\n",
+    "dataset = load_dataset(\"Etherll/kaira\", split = \"train\")\n",
     "dataset = dataset.cast_column(\"audio\", Audio(sampling_rate = 24000))"
    ]
   },
@@ -4334,7 +4334,7 @@
    },
    "outputs": [],
    "source": [
-    "input_text = \"Hey there my name is Elise, and I'm a speech generation model that can sound like a person.\""
+    "input_text = \"Hey there my name is Kaira, and I'm a speech generation model that can sound like a person.\""
    ]
   },
   {

--- a/nb/Sesame_CSM_(1B)-TTS.ipynb
+++ b/nb/Sesame_CSM_(1B)-TTS.ipynb
@@ -162,7 +162,7 @@
     "<a name=\"Data\"></a>\n",
     "### Data Prep  \n",
     "\n",
-    "We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
+    "We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
    ]
   },
   {
@@ -180,7 +180,7 @@
     "from transformers import AutoProcessor\n",
     "processor = AutoProcessor.from_pretrained(\"unsloth/csm-1b\")\n",
     "\n",
-    "raw_ds = load_dataset(\"MrDragonFox/Elise\", split = \"train\")\n",
+    "raw_ds = load_dataset(\"Etherll/kaira\", split = \"train\")\n",
     "\n",
     "# Getting the speaker id is important for multi-speaker models and speaker consistency\n",
     "speaker_key = \"source\"\n",

--- a/nb/Spark_TTS_(0_5B).ipynb
+++ b/nb/Spark_TTS_(0_5B).ipynb
@@ -202,7 +202,7 @@
     "<a name=\"Data\"></a>\n",
     "### Data Prep  \n",
     "\n",
-    "We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
+    "We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
    ]
   },
   {
@@ -222,7 +222,7 @@
    "outputs": [],
    "source": [
     "from datasets import load_dataset\n",
-    "dataset = load_dataset(\"MrDragonFox/Elise\", split = \"train\")"
+    "dataset = load_dataset(\"Etherll/kaira\", split = \"train\")"
    ]
   },
   {
@@ -1231,7 +1231,7 @@
    },
    "outputs": [],
    "source": [
-    "input_text = \"Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person.\"\n",
+    "input_text = \"Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person.\"\n",
     "\n",
     "chosen_voice = None # None for single-speaker"
    ]
@@ -1261,7 +1261,7 @@
      "output_type": "display_data",
      "data": {
       "text/plain": [
-       "Generating speech for: 'Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person.'\n",
+       "Generating speech for: 'Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person.'\n",
        "Generating token sequence...\n",
        "Token sequence generated.\n",
        "Found 348 semantic tokens.\n",
@@ -1271,7 +1271,7 @@
        "Audio saved to generated_speech_controllable.wav"
       ],
       "text/html": [
-       "<pre>Generating speech for: &#x27;Hey there my name is Elise, &lt;giggles&gt; and I&#x27;m a speech generation model that can sound like a person.&#x27;\n",
+       "<pre>Generating speech for: &#x27;Hey there my name is Kaira, &lt;giggle&gt; and I&#x27;m a speech generation model that can sound like a person.&#x27;\n",
        "Generating token sequence...\n",
        "Token sequence generated.\n",
        "Found 348 semantic tokens.\n",

--- a/nb/Whisper.ipynb
+++ b/nb/Whisper.ipynb
@@ -415,7 +415,7 @@
     "<a name=\"Data\"></a>\n",
     "### Data Prep  \n",
     "\n",
-    "We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio**. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
+    "We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio**. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
    ]
   },
   {
@@ -538,7 +538,7 @@
     "        \"labels\": tokenized_text.input_ids,\n",
     "    }\n",
     "from datasets import load_dataset, Audio\n",
-    "dataset = load_dataset(\"MrDragonFox/Elise\", split = \"train\")\n",
+    "dataset = load_dataset(\"Etherll/kaira\", split = \"train\")\n",
     "\n",
     "dataset = dataset.cast_column(\"audio\", Audio(sampling_rate = 16000))\n",
     "dataset = dataset.train_test_split(test_size = 0.06)\n",

--- a/original_template/Llasa_TTS_(1B).ipynb
+++ b/original_template/Llasa_TTS_(1B).ipynb
@@ -200,7 +200,7 @@
     "<a name=\"Data\"></a>\n",
     "### Data Prep  \n",
     "\n",
-    "We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format:\n",
+    "We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format:\n",
     "**text, audio**. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
    ]
   },
@@ -213,7 +213,7 @@
    "outputs": [],
    "source": [
     "from datasets import load_dataset\n",
-    "dataset = load_dataset(\"MrDragonFox/Elise\", split = \"train\")\n",
+    "dataset = load_dataset(\"Etherll/kaira\", split = \"train\")\n",
     "OUTPUT_DIR = 'processed_data_memmap'"
    ]
   },
@@ -1296,7 +1296,7 @@
    },
    "outputs": [],
    "source": [
-    "input_text = \"Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person.\""
+    "input_text = \"Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person.\""
    ]
   },
   {

--- a/original_template/Llasa_TTS_(3B).ipynb
+++ b/original_template/Llasa_TTS_(3B).ipynb
@@ -192,7 +192,7 @@
     "<a name=\"Data\"></a>\n",
     "### Data Prep  \n",
     "\n",
-    "We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format:\n",
+    "We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format:\n",
     "**text, audio**. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
    ]
   },
@@ -205,7 +205,7 @@
    "outputs": [],
    "source": [
     "from datasets import load_dataset\n",
-    "dataset = load_dataset(\"MrDragonFox/Elise\", split = \"train\")\n",
+    "dataset = load_dataset(\"Etherll/kaira\", split = \"train\")\n",
     "OUTPUT_DIR = 'processed_data_memmap'"
    ]
   },
@@ -1288,7 +1288,7 @@
    },
    "outputs": [],
    "source": [
-    "input_text = \"Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person.\""
+    "input_text = \"Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person.\""
    ]
   },
   {

--- a/original_template/Orpheus_(3B)-TTS.ipynb
+++ b/original_template/Orpheus_(3B)-TTS.ipynb
@@ -154,7 +154,7 @@
     "<a name=\"Data\"></a>\n",
     "### Data Prep  \n",
     "\n",
-    "We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
+    "We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
    ]
   },
   {
@@ -174,7 +174,7 @@
    "outputs": [],
    "source": [
     "from datasets import load_dataset\n",
-    "dataset = load_dataset(\"MrDragonFox/Elise\", split = \"train\")"
+    "dataset = load_dataset(\"Etherll/kaira\", split = \"train\")"
    ]
   },
   {
@@ -1858,7 +1858,7 @@
    "outputs": [],
    "source": [
     "prompts = [\n",
-    "    \"Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person.\",\n",
+    "    \"Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person.\",\n",
     "]\n",
     "\n",
     "chosen_voice = None # None for single-speaker"
@@ -1889,10 +1889,10 @@
      "output_type": "display_data",
      "data": {
       "text/plain": [
-       "Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person.\n"
+       "Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person.\n"
       ],
       "text/html": [
-       "<pre>Hey there my name is Elise, &lt;giggles&gt; and I&#x27;m a speech generation model that can sound like a person.\n",
+       "<pre>Hey there my name is Kaira, &lt;giggle&gt; and I&#x27;m a speech generation model that can sound like a person.\n",
        "</pre>"
       ]
      },

--- a/original_template/Oute_TTS_(1B).ipynb
+++ b/original_template/Oute_TTS_(1B).ipynb
@@ -209,7 +209,7 @@
     "<a name=\"Data\"></a>\n",
     "### Data Prep  \n",
     "\n",
-    "We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio**, but maintaining the correct structure is essential for optimal training."
+    "We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio**, but maintaining the correct structure is essential for optimal training."
    ]
   },
   {
@@ -221,7 +221,7 @@
    "outputs": [],
    "source": [
     "from datasets import load_dataset,Audio,Dataset\n",
-    "dataset = load_dataset(\"MrDragonFox/Elise\", split = \"train\")\n",
+    "dataset = load_dataset(\"Etherll/kaira\", split = \"train\")\n",
     "dataset = dataset.cast_column(\"audio\", Audio(sampling_rate=24000))"
    ]
   },
@@ -4344,7 +4344,7 @@
    },
    "outputs": [],
    "source": [
-    "input_text = \"Hey there my name is Elise, and I'm a speech generation model that can sound like a person.\""
+    "input_text = \"Hey there my name is Kaira, and I'm a speech generation model that can sound like a person.\""
    ]
   },
   {

--- a/original_template/Sesame_CSM_(1B)-TTS.ipynb
+++ b/original_template/Sesame_CSM_(1B)-TTS.ipynb
@@ -135,7 +135,7 @@
     "<a name=\"Data\"></a>\n",
     "### Data Prep  \n",
     "\n",
-    "We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
+    "We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
    ]
   },
   {
@@ -153,7 +153,7 @@
     "from transformers import AutoProcessor\n",
     "processor = AutoProcessor.from_pretrained(\"unsloth/csm-1b\")\n",
     "\n",
-    "raw_ds = load_dataset(\"MrDragonFox/Elise\", split=\"train\")\n",
+    "raw_ds = load_dataset(\"Etherll/kaira\", split=\"train\")\n",
     "\n",
     "# Getting the speaker id is important for multi-speaker models and speaker consistency\n",
     "speaker_key = \"source\"\n",

--- a/original_template/Spark_TTS_(0_5B).ipynb
+++ b/original_template/Spark_TTS_(0_5B).ipynb
@@ -175,7 +175,7 @@
     "<a name=\"Data\"></a>\n",
     "### Data Prep  \n",
     "\n",
-    "We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
+    "We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
    ]
   },
   {
@@ -195,7 +195,7 @@
    "outputs": [],
    "source": [
     "from datasets import load_dataset\n",
-    "dataset = load_dataset(\"MrDragonFox/Elise\", split = \"train\")"
+    "dataset = load_dataset(\"Etherll/kaira\", split = \"train\")"
    ]
   },
   {
@@ -1204,7 +1204,7 @@
    },
    "outputs": [],
    "source": [
-    "input_text = \"Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person.\"\n",
+    "input_text = \"Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person.\"\n",
     "\n",
     "chosen_voice = None # None for single-speaker"
    ]
@@ -1234,7 +1234,7 @@
      "output_type": "display_data",
      "data": {
       "text/plain": [
-       "Generating speech for: 'Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person.'\n",
+       "Generating speech for: 'Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person.'\n",
        "Generating token sequence...\n",
        "Token sequence generated.\n",
        "Found 348 semantic tokens.\n",
@@ -1244,7 +1244,7 @@
        "Audio saved to generated_speech_controllable.wav\n"
       ],
       "text/html": [
-       "<pre>Generating speech for: &#x27;Hey there my name is Elise, &lt;giggles&gt; and I&#x27;m a speech generation model that can sound like a person.&#x27;\n",
+       "<pre>Generating speech for: &#x27;Hey there my name is Kaira, &lt;giggle&gt; and I&#x27;m a speech generation model that can sound like a person.&#x27;\n",
        "Generating token sequence...\n",
        "Token sequence generated.\n",
        "Found 348 semantic tokens.\n",

--- a/original_template/Whisper.ipynb
+++ b/original_template/Whisper.ipynb
@@ -422,7 +422,7 @@
         "<a name=\"Data\"></a>\n",
         "### Data Prep  \n",
         "\n",
-        "We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio**. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
+        "We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio**. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training."
       ]
     },
     {
@@ -545,7 +545,7 @@
         "        \"labels\": tokenized_text.input_ids,\n",
         "    }\n",
         "from datasets import load_dataset, Audio\n",
-        "dataset = load_dataset(\"MrDragonFox/Elise\", split=\"train\")\n",
+        "dataset = load_dataset(\"Etherll/kaira\", split=\"train\")\n",
         "\n",
         "dataset = dataset.cast_column(\"audio\", Audio(sampling_rate=16000))\n",
         "dataset = dataset.train_test_split(test_size=0.06)\n",

--- a/python_scripts/AMD-Llasa_TTS_(1B).py
+++ b/python_scripts/AMD-Llasa_TTS_(1B).py
@@ -105,14 +105,14 @@ model = FastLanguageModel.get_peft_model(
 # <a name="Data"></a>
 # ### Data Prep  
 # 
-# We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format:
+# We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format:
 # **text, audio**. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
 
 # In[ ]:
 
 
 from datasets import load_dataset
-dataset = load_dataset("MrDragonFox/Elise", split = "train")
+dataset = load_dataset("Etherll/kaira", split = "train")
 OUTPUT_DIR = 'processed_data_memmap'
 
 
@@ -467,7 +467,7 @@ print(f"Peak reserved memory for training % of max memory = {lora_percentage} %.
 # In[ ]:
 
 
-input_text = "Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person."
+input_text = "Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person."
 
 
 # In[ ]:

--- a/python_scripts/AMD-Llasa_TTS_(3B).py
+++ b/python_scripts/AMD-Llasa_TTS_(3B).py
@@ -105,14 +105,14 @@ model = FastLanguageModel.get_peft_model(
 # <a name="Data"></a>
 # ### Data Prep  
 # 
-# We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format:
+# We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format:
 # **text, audio**. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
 
 # In[ ]:
 
 
 from datasets import load_dataset
-dataset = load_dataset("MrDragonFox/Elise", split = "train")
+dataset = load_dataset("Etherll/kaira", split = "train")
 OUTPUT_DIR = 'processed_data_memmap'
 
 
@@ -467,7 +467,7 @@ print(f"Peak reserved memory for training % of max memory = {lora_percentage} %.
 # In[ ]:
 
 
-input_text = "Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person."
+input_text = "Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person."
 
 
 # In[ ]:

--- a/python_scripts/AMD-Orpheus_(3B)-TTS.py
+++ b/python_scripts/AMD-Orpheus_(3B)-TTS.py
@@ -105,13 +105,13 @@ model = FastLanguageModel.get_peft_model(
 # <a name="Data"></a>
 # ### Data Prep  
 # 
-# We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
+# We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
 
 # In[ ]:
 
 
 from datasets import load_dataset
-dataset = load_dataset("MrDragonFox/Elise", split = "train")
+dataset = load_dataset("Etherll/kaira", split = "train")
 
 
 # In[ ]:
@@ -330,7 +330,7 @@ print(f"Peak reserved memory for training % of max memory = {lora_percentage} %.
 
 
 prompts = [
-    "Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person.",
+    "Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person.",
 ]
 
 chosen_voice = None # None for single-speaker

--- a/python_scripts/AMD-Oute_TTS_(1B).py
+++ b/python_scripts/AMD-Oute_TTS_(1B).py
@@ -101,13 +101,13 @@ model = FastModel.get_peft_model(
 # <a name="Data"></a>
 # ### Data Prep  
 # 
-# We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio**, but maintaining the correct structure is essential for optimal training.
+# We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio**, but maintaining the correct structure is essential for optimal training.
 
 # In[4]:
 
 
 from datasets import load_dataset,Audio,Dataset
-dataset = load_dataset("MrDragonFox/Elise", split = "train")
+dataset = load_dataset("Etherll/kaira", split = "train")
 dataset = dataset.cast_column("audio", Audio(sampling_rate = 24000))
 
 
@@ -376,7 +376,7 @@ print(f"Peak reserved memory for training % of max memory = {lora_percentage} %.
 # In[10]:
 
 
-input_text = "Hey there my name is Elise, and I'm a speech generation model that can sound like a person."
+input_text = "Hey there my name is Kaira, and I'm a speech generation model that can sound like a person."
 
 
 # In[11]:

--- a/python_scripts/AMD-Sesame_CSM_(1B)-TTS.py
+++ b/python_scripts/AMD-Sesame_CSM_(1B)-TTS.py
@@ -88,7 +88,7 @@ model = FastModel.get_peft_model(
 # <a name="Data"></a>
 # ### Data Prep  
 # 
-# We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
+# We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
 
 # In[ ]:
 
@@ -99,7 +99,7 @@ import os
 from transformers import AutoProcessor
 processor = AutoProcessor.from_pretrained("unsloth/csm-1b")
 
-raw_ds = load_dataset("MrDragonFox/Elise", split = "train")
+raw_ds = load_dataset("Etherll/kaira", split = "train")
 
 # Getting the speaker id is important for multi-speaker models and speaker consistency
 speaker_key = "source"

--- a/python_scripts/AMD-Spark_TTS_(0_5B).py
+++ b/python_scripts/AMD-Spark_TTS_(0_5B).py
@@ -114,13 +114,13 @@ model = FastModel.get_peft_model(
 # <a name="Data"></a>
 # ### Data Prep  
 # 
-# We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
+# We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
 
 # In[ ]:
 
 
 from datasets import load_dataset
-dataset = load_dataset("MrDragonFox/Elise", split = "train")
+dataset = load_dataset("Etherll/kaira", split = "train")
 
 
 # In[ ]:
@@ -316,7 +316,7 @@ print(f"Peak reserved memory for training % of max memory = {lora_percentage} %.
 # In[ ]:
 
 
-input_text = "Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person."
+input_text = "Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person."
 
 chosen_voice = None # None for single-speaker
 

--- a/python_scripts/AMD-Whisper.py
+++ b/python_scripts/AMD-Whisper.py
@@ -102,7 +102,7 @@ model = FastModel.get_peft_model(
 # <a name="Data"></a>
 # ### Data Prep  
 # 
-# We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio**. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
+# We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio**. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
 
 # In[4]:
 
@@ -128,7 +128,7 @@ def formatting_prompts_func(example):
         "labels": tokenized_text.input_ids,
     }
 from datasets import load_dataset, Audio
-dataset = load_dataset("MrDragonFox/Elise", split = "train")
+dataset = load_dataset("Etherll/kaira", split = "train")
 
 dataset = dataset.cast_column("audio", Audio(sampling_rate = 16000))
 dataset = dataset.train_test_split(test_size = 0.06)

--- a/python_scripts/Kaggle-Llasa_TTS_(1B).py
+++ b/python_scripts/Kaggle-Llasa_TTS_(1B).py
@@ -97,14 +97,14 @@ model = FastLanguageModel.get_peft_model(
 # <a name="Data"></a>
 # ### Data Prep  
 # 
-# We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format:
+# We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format:
 # **text, audio**. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
 
 # In[ ]:
 
 
 from datasets import load_dataset
-dataset = load_dataset("MrDragonFox/Elise", split = "train")
+dataset = load_dataset("Etherll/kaira", split = "train")
 OUTPUT_DIR = 'processed_data_memmap'
 
 
@@ -459,7 +459,7 @@ print(f"Peak reserved memory for training % of max memory = {lora_percentage} %.
 # In[ ]:
 
 
-input_text = "Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person."
+input_text = "Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person."
 
 
 # In[ ]:

--- a/python_scripts/Kaggle-Llasa_TTS_(3B).py
+++ b/python_scripts/Kaggle-Llasa_TTS_(3B).py
@@ -97,14 +97,14 @@ model = FastLanguageModel.get_peft_model(
 # <a name="Data"></a>
 # ### Data Prep  
 # 
-# We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format:
+# We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format:
 # **text, audio**. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
 
 # In[ ]:
 
 
 from datasets import load_dataset
-dataset = load_dataset("MrDragonFox/Elise", split = "train")
+dataset = load_dataset("Etherll/kaira", split = "train")
 OUTPUT_DIR = 'processed_data_memmap'
 
 
@@ -459,7 +459,7 @@ print(f"Peak reserved memory for training % of max memory = {lora_percentage} %.
 # In[ ]:
 
 
-input_text = "Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person."
+input_text = "Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person."
 
 
 # In[ ]:

--- a/python_scripts/Kaggle-Orpheus_(3B)-TTS.py
+++ b/python_scripts/Kaggle-Orpheus_(3B)-TTS.py
@@ -98,13 +98,13 @@ model = FastLanguageModel.get_peft_model(
 # <a name="Data"></a>
 # ### Data Prep  
 # 
-# We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
+# We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
 
 # In[ ]:
 
 
 from datasets import load_dataset
-dataset = load_dataset("MrDragonFox/Elise", split = "train")
+dataset = load_dataset("Etherll/kaira", split = "train")
 
 
 # In[ ]:
@@ -323,7 +323,7 @@ print(f"Peak reserved memory for training % of max memory = {lora_percentage} %.
 
 
 prompts = [
-    "Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person.",
+    "Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person.",
 ]
 
 chosen_voice = None # None for single-speaker

--- a/python_scripts/Kaggle-Oute_TTS_(1B).py
+++ b/python_scripts/Kaggle-Oute_TTS_(1B).py
@@ -99,13 +99,13 @@ model = FastModel.get_peft_model(
 # <a name="Data"></a>
 # ### Data Prep  
 # 
-# We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio**, but maintaining the correct structure is essential for optimal training.
+# We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio**, but maintaining the correct structure is essential for optimal training.
 
 # In[4]:
 
 
 from datasets import load_dataset,Audio,Dataset
-dataset = load_dataset("MrDragonFox/Elise", split = "train")
+dataset = load_dataset("Etherll/kaira", split = "train")
 dataset = dataset.cast_column("audio", Audio(sampling_rate = 24000))
 
 
@@ -374,7 +374,7 @@ print(f"Peak reserved memory for training % of max memory = {lora_percentage} %.
 # In[10]:
 
 
-input_text = "Hey there my name is Elise, and I'm a speech generation model that can sound like a person."
+input_text = "Hey there my name is Kaira, and I'm a speech generation model that can sound like a person."
 
 
 # In[11]:

--- a/python_scripts/Kaggle-Sesame_CSM_(1B)-TTS.py
+++ b/python_scripts/Kaggle-Sesame_CSM_(1B)-TTS.py
@@ -81,7 +81,7 @@ model = FastModel.get_peft_model(
 # <a name="Data"></a>
 # ### Data Prep  
 # 
-# We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
+# We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
 
 # In[ ]:
 
@@ -92,7 +92,7 @@ import os
 from transformers import AutoProcessor
 processor = AutoProcessor.from_pretrained("unsloth/csm-1b")
 
-raw_ds = load_dataset("MrDragonFox/Elise", split = "train")
+raw_ds = load_dataset("Etherll/kaira", split = "train")
 
 # Getting the speaker id is important for multi-speaker models and speaker consistency
 speaker_key = "source"

--- a/python_scripts/Kaggle-Spark_TTS_(0_5B).py
+++ b/python_scripts/Kaggle-Spark_TTS_(0_5B).py
@@ -106,13 +106,13 @@ model = FastModel.get_peft_model(
 # <a name="Data"></a>
 # ### Data Prep  
 # 
-# We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
+# We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
 
 # In[ ]:
 
 
 from datasets import load_dataset
-dataset = load_dataset("MrDragonFox/Elise", split = "train")
+dataset = load_dataset("Etherll/kaira", split = "train")
 
 
 # In[ ]:
@@ -308,7 +308,7 @@ print(f"Peak reserved memory for training % of max memory = {lora_percentage} %.
 # In[ ]:
 
 
-input_text = "Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person."
+input_text = "Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person."
 
 chosen_voice = None # None for single-speaker
 

--- a/python_scripts/Kaggle-Whisper.py
+++ b/python_scripts/Kaggle-Whisper.py
@@ -95,7 +95,7 @@ model = FastModel.get_peft_model(
 # <a name="Data"></a>
 # ### Data Prep  
 # 
-# We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio**. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
+# We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio**. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
 
 # In[4]:
 
@@ -121,7 +121,7 @@ def formatting_prompts_func(example):
         "labels": tokenized_text.input_ids,
     }
 from datasets import load_dataset, Audio
-dataset = load_dataset("MrDragonFox/Elise", split = "train")
+dataset = load_dataset("Etherll/kaira", split = "train")
 
 dataset = dataset.cast_column("audio", Audio(sampling_rate = 16000))
 dataset = dataset.train_test_split(test_size = 0.06)

--- a/python_scripts/Llasa_TTS_(1B).py
+++ b/python_scripts/Llasa_TTS_(1B).py
@@ -97,14 +97,14 @@ model = FastLanguageModel.get_peft_model(
 # <a name="Data"></a>
 # ### Data Prep  
 # 
-# We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format:
+# We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format:
 # **text, audio**. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
 
 # In[ ]:
 
 
 from datasets import load_dataset
-dataset = load_dataset("MrDragonFox/Elise", split = "train")
+dataset = load_dataset("Etherll/kaira", split = "train")
 OUTPUT_DIR = 'processed_data_memmap'
 
 
@@ -459,7 +459,7 @@ print(f"Peak reserved memory for training % of max memory = {lora_percentage} %.
 # In[ ]:
 
 
-input_text = "Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person."
+input_text = "Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person."
 
 
 # In[ ]:

--- a/python_scripts/Llasa_TTS_(3B).py
+++ b/python_scripts/Llasa_TTS_(3B).py
@@ -97,14 +97,14 @@ model = FastLanguageModel.get_peft_model(
 # <a name="Data"></a>
 # ### Data Prep  
 # 
-# We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format:
+# We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format:
 # **text, audio**. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
 
 # In[ ]:
 
 
 from datasets import load_dataset
-dataset = load_dataset("MrDragonFox/Elise", split = "train")
+dataset = load_dataset("Etherll/kaira", split = "train")
 OUTPUT_DIR = 'processed_data_memmap'
 
 
@@ -459,7 +459,7 @@ print(f"Peak reserved memory for training % of max memory = {lora_percentage} %.
 # In[ ]:
 
 
-input_text = "Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person."
+input_text = "Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person."
 
 
 # In[ ]:

--- a/python_scripts/Orpheus_(3B)-TTS.py
+++ b/python_scripts/Orpheus_(3B)-TTS.py
@@ -98,13 +98,13 @@ model = FastLanguageModel.get_peft_model(
 # <a name="Data"></a>
 # ### Data Prep  
 # 
-# We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
+# We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
 
 # In[ ]:
 
 
 from datasets import load_dataset
-dataset = load_dataset("MrDragonFox/Elise", split = "train")
+dataset = load_dataset("Etherll/kaira", split = "train")
 
 
 # In[ ]:
@@ -323,7 +323,7 @@ print(f"Peak reserved memory for training % of max memory = {lora_percentage} %.
 
 
 prompts = [
-    "Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person.",
+    "Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person.",
 ]
 
 chosen_voice = None # None for single-speaker

--- a/python_scripts/Oute_TTS_(1B).py
+++ b/python_scripts/Oute_TTS_(1B).py
@@ -99,13 +99,13 @@ model = FastModel.get_peft_model(
 # <a name="Data"></a>
 # ### Data Prep  
 # 
-# We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio**, but maintaining the correct structure is essential for optimal training.
+# We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio**, but maintaining the correct structure is essential for optimal training.
 
 # In[4]:
 
 
 from datasets import load_dataset,Audio,Dataset
-dataset = load_dataset("MrDragonFox/Elise", split = "train")
+dataset = load_dataset("Etherll/kaira", split = "train")
 dataset = dataset.cast_column("audio", Audio(sampling_rate = 24000))
 
 
@@ -374,7 +374,7 @@ print(f"Peak reserved memory for training % of max memory = {lora_percentage} %.
 # In[10]:
 
 
-input_text = "Hey there my name is Elise, and I'm a speech generation model that can sound like a person."
+input_text = "Hey there my name is Kaira, and I'm a speech generation model that can sound like a person."
 
 
 # In[11]:

--- a/python_scripts/Sesame_CSM_(1B)-TTS.py
+++ b/python_scripts/Sesame_CSM_(1B)-TTS.py
@@ -81,7 +81,7 @@ model = FastModel.get_peft_model(
 # <a name="Data"></a>
 # ### Data Prep  
 # 
-# We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
+# We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
 
 # In[ ]:
 
@@ -92,7 +92,7 @@ import os
 from transformers import AutoProcessor
 processor = AutoProcessor.from_pretrained("unsloth/csm-1b")
 
-raw_ds = load_dataset("MrDragonFox/Elise", split = "train")
+raw_ds = load_dataset("Etherll/kaira", split = "train")
 
 # Getting the speaker id is important for multi-speaker models and speaker consistency
 speaker_key = "source"

--- a/python_scripts/Spark_TTS_(0_5B).py
+++ b/python_scripts/Spark_TTS_(0_5B).py
@@ -106,13 +106,13 @@ model = FastModel.get_peft_model(
 # <a name="Data"></a>
 # ### Data Prep  
 # 
-# We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
+# We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio** for single-speaker models or **source, text, audio** for multi-speaker models. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
 
 # In[ ]:
 
 
 from datasets import load_dataset
-dataset = load_dataset("MrDragonFox/Elise", split = "train")
+dataset = load_dataset("Etherll/kaira", split = "train")
 
 
 # In[ ]:
@@ -308,7 +308,7 @@ print(f"Peak reserved memory for training % of max memory = {lora_percentage} %.
 # In[ ]:
 
 
-input_text = "Hey there my name is Elise, <giggles> and I'm a speech generation model that can sound like a person."
+input_text = "Hey there my name is Kaira, <giggle> and I'm a speech generation model that can sound like a person."
 
 chosen_voice = None # None for single-speaker
 

--- a/python_scripts/Whisper.py
+++ b/python_scripts/Whisper.py
@@ -95,7 +95,7 @@ model = FastModel.get_peft_model(
 # <a name="Data"></a>
 # ### Data Prep  
 # 
-# We will use the `MrDragonFox/Elise`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio**. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
+# We will use the `Etherll/kaira`, which is designed for training TTS models. Ensure that your dataset follows the required format: **text, audio**. You can modify this section to accommodate your own dataset, but maintaining the correct structure is essential for optimal training.
 
 # In[4]:
 
@@ -121,7 +121,7 @@ def formatting_prompts_func(example):
         "labels": tokenized_text.input_ids,
     }
 from datasets import load_dataset, Audio
-dataset = load_dataset("MrDragonFox/Elise", split = "train")
+dataset = load_dataset("Etherll/kaira", split = "train")
 
 dataset = dataset.cast_column("audio", Audio(sampling_rate = 16000))
 dataset = dataset.train_test_split(test_size = 0.06)

--- a/scripts/model_created_at.csv
+++ b/scripts/model_created_at.csv
@@ -2,6 +2,7 @@ model_repo,created_at,downloads,likes,base_model,fetched_at,status
 AI4Math/MathVista,,0,0,,2026-04-08T08:58:06Z,not_found
 AudioProcessor/DacInterface,,0,0,,2026-04-08T08:58:06Z,not_found
 Dao-AILab/causal-conv1d,,0,0,,2026-04-18T00:43:34Z,not_found
+Etherll/kaira,2026-06-10T15:54:00Z,0,0,,2026-06-10T18:15:12Z,ok
 Fallback/augmentation,,0,0,,2026-04-08T08:58:06Z,not_found
 Flag/unflag,,0,0,,2026-04-08T11:44:51Z,not_found
 FreedomIntelligence/alpaca-gpt4-korean,,0,0,,2026-04-08T08:58:06Z,not_found
@@ -15,7 +16,6 @@ LiquidAI/LFM2-700M,2025-07-10T12:01:39Z,12417,110,,2026-04-08T08:58:28Z,ok
 LiquidAI/LFM2.5-1.2B-Base,2026-01-05T16:27:32Z,18776,126,,2026-05-18T11:06:35Z,ok
 LiquidAI/LFM2.5-1.2B-Instruct,2026-01-06T00:28:46Z,305212,554,LiquidAI/LFM2.5-1.2B-Base,2026-04-08T08:58:28Z,ok
 LiquidAI/LFM2.5-VL-1.6B,2026-01-05T19:07:50Z,83139,284,LiquidAI/LFM2.5-1.2B-Base,2026-05-18T11:06:35Z,ok
-MrDragonFox/Elise,,0,0,,2026-04-08T08:58:06Z,not_found
 OuteAI/Llama-OuteTTS-1.0-1B,2025-04-06T14:22:37Z,4786,240,,2026-05-18T11:06:35Z,ok
 Qwen/Qwen2-VL-2B,2024-09-05T07:14:45Z,3286,62,,2026-04-08T09:26:16Z,ok
 Qwen/Qwen2-VL-2B-Instruct,2024-08-28T09:02:15Z,2206780,497,Qwen/Qwen2-VL-2B,2026-04-08T08:58:28Z,ok


### PR DESCRIPTION
Replace dataset references from "MrDragonFox/Elise" to "Etherll/kaira" across molab scripts, notebooks, original templates, and python_scripts so code loads the new dataset. Update example/demo prompts to use the name "Kaira" (and adjust the `<giggles>` tag to `<giggle>` where applicable) for consistency. Also includes a minor metadata update to scripts/model_created_at.csv.