### PR TITLE
Pin marimo and ruff exactly to fix the molab parity hard gate

### DIFF
--- a/.github/workflows/notebooks-tests-ci.yml
+++ b/.github/workflows/notebooks-tests-ci.yml
@@ -94,7 +94,9 @@ jobs:
         #             every generated notebook to re-wrap the lines that
         #             marimo's IR conversion ast-unparses (rename pass).
         #             Pinned so regeneration is byte-stable across CI runs.
-        run: pip install 'marimo>=0.23,<0.24' 'ruff>=0.15,<0.16'
+        # Exact pins: marimo stamps its version into __generated_with, so
+        # any release drifts parity. Bump pins together with a regen commit.
+        run: pip install 'marimo==0.23.8' 'ruff==0.15.16'
 
       - name: tests/test_notebook_json_validity.py
         run: |

--- a/README.md
+++ b/README.md
@@ -767,6 +767,9 @@ Run any of these on [molab](https://molab.marimo.io), Marimo's hosted GPU notebo
 | **Gemma3** **(27B)** | Conversational | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Gemma3_(27B)_A100-Conversational.py) |
 | **Gemma3** **(4B)** | Conversational | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Gemma3_(4B).py) |
 | **Gemma3** **(4B)** | Vision | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Gemma3_(4B)-Vision.py) |
+| **Gemma4** **(12B)** | Audio | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Gemma4_(12B)_Audio.py) |
+| **Gemma4** **(12B)** |  | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Gemma4_(12B)_Text.py) |
+| **Gemma4** **(12B)** | Vision | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Gemma4_(12B)_Vision.py) |
 | **Gemma4** **(26B A4B)** | Conversational | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Gemma4_(26B_A4B)-Text.py) |
 | **Gemma4** **(26B A4B)** | Vision | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Gemma4_(26B_A4B)-Vision.py) |
 | **Gemma4** **(31B)** | Conversational | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Gemma4_(31B)-Text.py) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,11 @@ dependencies = [
 #     names it had to rename for the single-definition rule, which
 #     collapses multi-line calls onto one long line; ruff re-wraps them
 #     readably.  Pinned so regeneration is byte-stable across CI runs.
+#   Exact pins: marimo stamps its version into __generated_with, so any
+#     release drifts parity. Bump pins together with a regen commit.
 generator = [
-    "marimo>=0.23,<0.24",
-    "ruff>=0.15,<0.16",
+    "marimo==0.23.8",
+    "ruff==0.15.16",
 ]
 
 [tool.pytest.ini_options]

--- a/scripts/molab_readme.py
+++ b/scripts/molab_readme.py
@@ -191,7 +191,9 @@ def _row(nb: "MolabNotebook") -> str:
 
 
 _INTRO = (
-    "# 🍃 Open in molab\n"
+    # Heading matches the hand-edited README (b87c708); badges keep the
+    # "Open in molab" wording the tests require.
+    "# 🍃 Molab Notebooks\n"
     "\n"
     "Run any of these on [molab](https://molab.marimo.io), Marimo's "
     "hosted GPU notebooks. They're reactive: change a value in one "


### PR DESCRIPTION
### What

Every PR is currently failing the `notebook static checks (HARD GATE)` job in `tests/test_molab_generation_parity.py` with `DRIFT DETECTED` on all 136 molab notebooks (see #286 and #285).

Root cause: marimo stamps its own version into the `__generated_with` line of every generated notebook. The committed `molab/*.py` files were generated with marimo 0.23.8, but CI installs `marimo>=0.23,<0.24`, which started resolving to 0.23.9 after its PyPI release on June 4. Regenerating under 0.23.9 changes that one line in every file, so the byte-for-byte parity check fails everywhere. No PR content is at fault.

### Changes

- Pin `marimo==0.23.8` (matches the committed `__generated_with` stamp) and `ruff==0.15.16` (freezes the `ruff format` pass) in `.github/workflows/notebooks-tests-ci.yml` and in the `[generator]` extra of `pyproject.toml`. The comments already said these were pinned for byte-stability, but a range floating within the minor never was.
- Add the missing Gemma4 (12B) Audio / Text / Vision rows to the README molab table via `python scripts/molab_generate.py --readme`. #284 added these notebooks without refreshing the README section, and `test_molab_readme_links.py` (also part of the hard gate, currently masked because it is skipped after the parity failure) starts failing on them the moment parity is green again.
- Make the README renderer emit the `Molab Notebooks` heading from b87c708 so regeneration stops reverting that manual edit. The `Open in molab` wording check still passes through the badge text.

### Verification

- Replicated the full gate locally on Python 3.12 with the pinned versions: all suites pass (5648 tests; the only failure before the README fix was the badge test, which this PR fixes).
- Regeneration under the pins is byte-stable: zero diffs across all 136 `molab/*.py` files, and the README gains only the three badge rows.
- Workflow YAML and `pyproject.toml` parse cleanly; `scripts/molab_readme.py` passes an `ast.parse` check.

Future marimo or ruff bumps should update both pins and commit the regen in the same PR. This unblocks #286, #285 and any other open PR hitting the gate.
