### PR TITLE
Whisper: pass processing_class instead of removed tokenizer kwarg

### DIFF
--- a/nb/Kaggle-Whisper.ipynb
+++ b/nb/Kaggle-Whisper.ipynb
@@ -675,7 +675,7 @@
     "    train_dataset = train_dataset,\n",
     "    data_collator = DataCollatorSpeechSeq2SeqWithPadding(processor = tokenizer),\n",
     "    eval_dataset = test_dataset,\n",
-    "    tokenizer = tokenizer.feature_extractor,\n",
+    "    processing_class = tokenizer.feature_extractor,\n",
     "    compute_metrics = compute_metrics,\n",
     "    args = Seq2SeqTrainingArguments(\n",
     "        # predict_with_generate = True,\n",

--- a/nb/Whisper.ipynb
+++ b/nb/Whisper.ipynb
@@ -675,7 +675,7 @@
     "    train_dataset = train_dataset,\n",
     "    data_collator = DataCollatorSpeechSeq2SeqWithPadding(processor = tokenizer),\n",
     "    eval_dataset = test_dataset,\n",
-    "    tokenizer = tokenizer.feature_extractor,\n",
+    "    processing_class = tokenizer.feature_extractor,\n",
     "    compute_metrics = compute_metrics,\n",
     "    args = Seq2SeqTrainingArguments(\n",
     "        # predict_with_generate = True,\n",

--- a/original_template/Whisper.ipynb
+++ b/original_template/Whisper.ipynb
@@ -682,7 +682,7 @@
         "    train_dataset = train_dataset,\n",
         "    data_collator = DataCollatorSpeechSeq2SeqWithPadding(processor=tokenizer),\n",
         "    eval_dataset = test_dataset,\n",
-        "    tokenizer = tokenizer.feature_extractor,\n",
+        "    processing_class = tokenizer.feature_extractor,\n",
         "    compute_metrics=compute_metrics,\n",
         "    args = Seq2SeqTrainingArguments(\n",
         "        # predict_with_generate=True,\n",

--- a/python_scripts/Kaggle-Whisper.py
+++ b/python_scripts/Kaggle-Whisper.py
@@ -195,7 +195,7 @@ trainer = Seq2SeqTrainer(
     train_dataset = train_dataset,
     data_collator = DataCollatorSpeechSeq2SeqWithPadding(processor = tokenizer),
     eval_dataset = test_dataset,
-    tokenizer = tokenizer.feature_extractor,
+    processing_class = tokenizer.feature_extractor,
     compute_metrics = compute_metrics,
     args = Seq2SeqTrainingArguments(
         # predict_with_generate = True,

--- a/python_scripts/Whisper.py
+++ b/python_scripts/Whisper.py
@@ -195,7 +195,7 @@ trainer = Seq2SeqTrainer(
     train_dataset = train_dataset,
     data_collator = DataCollatorSpeechSeq2SeqWithPadding(processor = tokenizer),
     eval_dataset = test_dataset,
-    tokenizer = tokenizer.feature_extractor,
+    processing_class = tokenizer.feature_extractor,
     compute_metrics = compute_metrics,
     args = Seq2SeqTrainingArguments(
         # predict_with_generate = True,


### PR DESCRIPTION
transformers 5.x removed the deprecated tokenizer argument from Seq2SeqTrainer, so the Whisper notebook fails at trainer construction on current installs with:

```
TypeError: Seq2SeqTrainer.__init__() got an unexpected keyword argument 'tokenizer'
```

4.x has warned about this for a while (the notebook's own saved output shows the FutureWarning pointing at processing_class), and processing_class accepts the feature extractor on both 4.57.6 and 5.x, so the rename is forward and backward compatible.

Changes: one line in original_template/Whisper.ipynb, synced to nb/Whisper.ipynb, nb/Kaggle-Whisper.ipynb, python_scripts/Whisper.py and python_scripts/Kaggle-Whisper.py. I avoided a full update_all_notebooks.py regeneration on purpose: it currently rewrites unrelated notebooks (install blocks, embedded outputs), which would bury this one line change.

Validated by running the patched notebook end to end (training, transcription inference, LoRA save) on transformers 5.11 inside the unsloth Docker image on a B200: passes in 2 minutes. JSON validity checked for all three ipynb files and AST checked for both python scripts.