### PR TITLE
Fix token length filter in Qwen3 MoE notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -746,6 +746,7 @@ Run any of these on [molab](https://molab.marimo.io), Marimo's hosted GPU notebo
 | **Deepseek OCR** **(3B)** | Eval | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Deepseek_OCR_(3B)-Eval.py) |
 | **Deepseek OCR** **(3B)** | Evaluation | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Deepseek_OCR_(3B)-Evaluation.py) |
 | **Deepseek OCR 2** **(3B)** | Fine Tuning | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/Deepseek_OCR_2_(3B).py) |
+| **DiffusionGemma** **(26B A4B)** |  | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/DiffusionGemma_(26B-A4B)-Sudoku.py) |
 | **ERNIE 4 5 21B A3B PT** | Conversational | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/ERNIE_4_5_21B_A3B_PT-Conversational.py) |
 | **ERNIE 4 5 VL 28B A3B PT** | Vision | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/ERNIE_4_5_VL_28B_A3B_PT_Vision.py) |
 | **EmbeddingGemma** **(300M)** | Embeddings | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/unslothai/notebooks/blob/main/molab/EmbeddingGemma_(300M).py) |

--- a/molab/DiffusionGemma_(26B-A4B)-Sudoku.py
+++ b/molab/DiffusionGemma_(26B-A4B)-Sudoku.py
@@ -1,0 +1,524 @@
+# /// script
+# requires-python = ">=3.10,<3.14"
+# dependencies = [
+#     "accelerate",
+#     "bitsandbytes>=0.43.0",
+#     "datasets==4.3.0",
+#     "hf_transfer",
+#     "huggingface_hub>=0.34.0",
+#     "marimo",
+#     "peft",
+#     "protobuf",
+#     "sentencepiece",
+#     "tokenizers>=0.22.0,<=0.23.0",
+#     "torchao>=0.16.0",
+#     "transformers==5.11.0",
+#     "triton>=3.2.0",
+#     "trl",
+#     "unsloth @ git+https://github.com/unslothai/unsloth",
+#     "unsloth_zoo @ git+https://github.com/unslothai/unsloth-zoo",
+# ]
+#
+# [tool.uv]
+# no-build-package = [
+#     "bitsandbytes",
+#     "triton",
+#     "vllm",
+#     "xformers",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.23.8"
+app = marimo.App()
+
+
+@app.cell
+def _():
+    import marimo as mo
+
+    return (mo,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    To run this notebook on your A100 molab Pro instance, hit the **▶ Run all** button in the bottom-right corner - or use `Ctrl/Cmd + Shift + R`.
+    <div class="align-center">
+    <a href="https://unsloth.ai/"><img src="https://github.com/unslothai/unsloth/raw/main/images/unsloth%20new%20logo.png" width="115"></a>
+    <a href="https://discord.gg/unsloth"><img src="https://github.com/unslothai/unsloth/raw/main/images/Discord button.png" width="145"></a>
+    <a href="https://unsloth.ai/docs/"><img src="https://github.com/unslothai/unsloth/blob/main/images/documentation%20green%20button.png?raw=true" width="125"></a> Join Discord if you need help + ⭐ <i>Star us on <a href="https://github.com/unslothai/unsloth">Github</a> </i> ⭐
+    </div>
+
+    To install Unsloth on your local device, follow [our guide](https://unsloth.ai/docs/get-started/install). This notebook is licensed [LGPL-3.0](https://github.com/unslothai/notebooks?tab=LGPL-3.0-1-ov-file#readme).
+
+    You will learn how to do [data prep](#Data), how to [train](#Train), how to [run the model](#Inference), & how to save it
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ### News
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    Introducing **Unsloth Studio** - a new open source, no-code web UI to train and run LLMs. [Blog](https://unsloth.ai/docs/new/studio) • [Notebook](https://github.com/unslothai/unsloth/blob/main/studio/Unsloth_Studio_Colab.ipynb)
+
+    <table><tr>
+    <td align="center"><a href="https://unsloth.ai/docs/new/studio"><img src="https://unsloth.ai/docs/~gitbook/image?url=https%3A%2F%2F3215535692-files.gitbook.io%2F~%2Ffiles%2Fv0%2Fb%2Fgitbook-x-prod.appspot.com%2Fo%2Fspaces%252FxhOjnexMCB3dmuQFQ2Zq%252Fuploads%252FxV1PO5DbF3ksB51nE2Tw%252Fmore%2520cropped%2520ui%2520for%2520homepage.png%3Falt%3Dmedia%26token%3Df75942c9-3d8d-4b59-8ba2-1a4a38de1b86&width=376&dpr=3&quality=100&sign=a663c397&sv=2" width="200" height="120" alt="Unsloth Studio Training UI"></a><br><sub><b>Train models</b> — no code needed</sub></td>
+    <td align="center"><a href="https://unsloth.ai/docs/new/studio"><img src="https://unsloth.ai/docs/~gitbook/image?url=https%3A%2F%2F3215535692-files.gitbook.io%2F~%2Ffiles%2Fv0%2Fb%2Fgitbook-x-prod.appspot.com%2Fo%2Fspaces%252FxhOjnexMCB3dmuQFQ2Zq%252Fuploads%252FRCnTAZ6Uh88DIlU3g0Ij%252Fmainpage%2520unsloth.png%3Falt%3Dmedia%26token%3D837c96b6-bd09-4e81-bc76-fa50421e9bfb&width=376&dpr=3&quality=100&sign=c1a39da1&sv=2" width="200" height="120" alt="Unsloth Studio Chat UI"></a><br><sub><b>Run GGUF models</b> on Mac, Windows & Linux</sub></td>
+    </tr></table>
+
+    Train MoEs - DeepSeek, GLM, Qwen and gpt-oss 12x faster with 35% less VRAM. [Blog](https://unsloth.ai/docs/new/faster-moe)
+
+    Ultra Long-Context Reinforcement Learning is here with 7x more context windows! [Blog](https://unsloth.ai/docs/new/grpo-long-context)
+
+    New in Reinforcement Learning: [FP8 RL](https://unsloth.ai/docs/new/fp8-reinforcement-learning) • [Vision RL](https://unsloth.ai/docs/new/vision-reinforcement-learning-vlm-rl) • [Standby](https://unsloth.ai/docs/basics/memory-efficient-rl) • [gpt-oss RL](https://unsloth.ai/docs/new/gpt-oss-reinforcement-learning)
+
+    Visit our docs for all our [model uploads](https://unsloth.ai/docs/get-started/unsloth-model-catalog) and [notebooks](https://unsloth.ai/docs/get-started/unsloth-notebooks).
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ### Unsloth
+
+    **Goal: finetune DiffusionGemma to solve Sudoku.** Sudoku is a global-constraint task - the answer must be consistent across the whole 9x9 grid at once, and solving means going back to **revise** wrong cells. An autoregressive model commits each cell left to right and cannot take it back; DiffusionGemma denoises the entire grid in parallel and revises cells over steps, which is exactly the capability this task needs.
+
+    DiffusionGemma needs a transformers build that ships the DiffusionGemma classes; `FastModel` auto-detects the diffusion architecture and routes to the transformers-only slow path.
+    """)
+    return
+
+
+@app.cell
+def _():
+    from unsloth import FastModel
+    import torch
+
+    # DiffusionGemma is a 26B-A4B block-diffusion MoE on the Gemma-4 backbone. FastModel auto-detects the
+    # diffusion model_type and routes to the transformers-only FastDiffusionModel slow path.
+    # It is ~52GB in bf16: the 128 MoE experts alone are ~46GB and stay bf16 (fused 3D params, so bnb 4bit
+    # cannot shrink them). Use a >= ~50GB GPU (A100 80GB / H100 / B200); a 40GB GPU offloads weights to the
+    # meta/CPU device and the run becomes impractically slow.
+    if torch.cuda.is_available():
+        free_gb = torch.cuda.mem_get_info()[0] / 1e9
+        if free_gb < 50:
+            print(
+                f"[warn] {free_gb:.0f}GB free < ~52GB needed: weights will offload (meta/CPU) and run very "
+                "slowly. Use an 80GB GPU (A100 80GB / H100) for a real run."
+            )
+
+    model, tokenizer = FastModel.from_pretrained(
+        model_name="unsloth/diffusiongemma-26B-A4B-it",
+        dtype=torch.bfloat16,
+        load_in_4bit=False,  # 4bit cannot shrink the ~46GB of MoE experts, so it needs ~50GB either way
+        # token = "YOUR_HF_TOKEN",
+    )
+    processor = (  # diffusion checkpoints ship a processor (chat template + tokenizer)
+        tokenizer  # diffusion checkpoints ship a processor (chat template + tokenizer)
+    )
+    vocab = model.config.text_config.vocab_size
+    canvas_len = model.config.canvas_length  # 256-token generation canvas
+    print("vocab", vocab, "| canvas", canvas_len)
+    return FastModel, canvas_len, model, processor, torch, vocab
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    We add LoRA adapters so we only train a few percent of the parameters. We target the attention and the dense MLP of the shared Gemma-4 backbone; the 128 fused MoE experts stay frozen.
+    """)
+    return
+
+
+@app.cell
+def _(FastModel, model):
+    model_1 = FastModel.get_peft_model(
+        model, r=64, lora_alpha=128, use_gradient_checkpointing=False
+    )
+    return (model_1,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    <a name="Data"></a>
+    # Sudoku dataset
+
+    We generate puzzle -> solution pairs procedurally, each with a **unique** solution (verified by a solver), so the target is the only correct answer. The 9x9 grid is written as 9 newline-separated rows of compact digits; the Gemma tokenizer splits digits individually, so every cell is exactly one token at a fixed canvas position. `0` marks an empty cell.
+    """)
+    return
+
+
+@app.cell
+def _():
+    import random
+
+    def _solve_count(g, limit=2):
+        best, best_cands = (
+            -1,
+            None,
+        )  # count solutions up to `limit` via MRV backtracking; g is list[81], 0 = empty
+        for i in range(81):
+            if g[i] != 0:
+                continue
+            r, c = divmod(i, 9)
+            used = set()
+            for k in range(9):
+                used.add(g[r * 9 + k])
+                used.add(g[k * 9 + c])
+            br, bc = (r // 3 * 3, c // 3 * 3)
+            for dr in range(3):
+                for dc in range(3):
+                    used.add(g[(br + dr) * 9 + (bc + dc)])
+            cands = [d for d in range(1, 10) if d not in used]
+            if not cands:
+                return 0
+            if best_cands is None or len(cands) < len(best_cands):
+                best, best_cands = (i, cands)
+                if len(cands) == 1:
+                    break
+        if best == -1:
+            return 1
+        total = 0  # random complete solution by shuffled backtracking
+        for d in best_cands:
+            g[best] = d
+            total = total + _solve_count(g, limit)
+            g[best] = 0
+            if total >= limit:
+                break
+        return total
+
+    def _full_grid(rng):
+        g = [0] * 81
+
+        def fill(i):
+            if i == 81:
+                return True
+            if g[i] != 0:
+                return fill(i + 1)
+            r, c = divmod(i, 9)
+            used = set()
+            for k in range(9):  # remove `holes` cells while keeping the solution unique
+                used.add(g[r * 9 + k])
+                used.add(g[k * 9 + c])
+            br, bc = (r // 3 * 3, c // 3 * 3)
+            for dr in range(3):
+                for dc in range(3):
+                    used.add(g[(br + dr) * 9 + (bc + dc)])
+            cands = [d for d in range(1, 10) if d not in used]
+            rng.shuffle(cands)
+            for d in cands:
+                g[i] = d
+                if fill(i + 1):
+                    return True
+                g[i] = 0
+            return False
+
+        fill(0)
+        return g  # holes_lo..holes_hi givens
+
+    def _make_puzzle(full, holes, rng):
+        g = full[:]
+        order = list(range(81))
+        rng.shuffle(order)
+        removed = 0
+        for i in order:
+            if removed >= holes:
+                break
+            # A few thousand puzzles is enough to see learning; scale up for higher solve rates.
+            saved = g[i]
+            g[i] = 0
+            if _solve_count(g[:], 2) != 1:
+                g[i] = saved
+            else:
+                removed = removed + 1
+        return (g, removed)
+
+    def _grid_str(g):
+        return "\n".join(
+            ("".join((str(g[r * 9 + c]) for c in range(9))) for r in range(9))
+        )
+
+    PROMPT = "Solve this Sudoku puzzle. 0 marks an empty cell. Reply with the completed 9x9 grid.\n{puzzle}"
+
+    def make_example(seed, holes_lo=36, holes_hi=46):
+        rng = random.Random(seed)
+        full = _full_grid(rng)
+        holes = rng.randint(81 - holes_hi, 81 - holes_lo)  # holes_lo..holes_hi givens
+        puz, _ = _make_puzzle(full, holes, rng)
+        return {
+            "messages": [
+                {"role": "user", "content": PROMPT.format(puzzle=_grid_str(puz))},
+                {"role": "assistant", "content": _grid_str(full)},
+            ],
+            "puzzle": "".join(map(str, puz)),
+            "solution": "".join(map(str, full)),
+        }
+
+    N_TRAIN, N_EVAL = (3000, 200)
+    train_rows = [make_example(s) for s in range(N_TRAIN)]
+    eval_rows = [make_example(s) for s in range(10000, 10000 + N_EVAL)]
+    print(len(train_rows), "train /", len(eval_rows), "eval puzzles")
+    return eval_rows, random, train_rows
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    A training example - the user message is the puzzle, the assistant message is the solved grid:
+    """)
+    return
+
+
+@app.cell
+def _(train_rows):
+    print(train_rows[0]["messages"][0]["content"])
+    print("---")
+    print(train_rows[0]["messages"][1]["content"])
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    <a name="Train"></a>
+    # Block-diffusion finetuning
+
+    DiffusionGemma is not trained the autoregressive way (no `SFTTrainer`). Instead we use its own block-diffusion objective: pad the target solution to the 256-token canvas, **corrupt** the canvas by replacing each token with probability `t` by a random token, then ask the model to predict the clean grid. The loss is cross-entropy on the solution tokens plus the `eos` (the padding tail is ignored).
+    """)
+    return
+
+
+@app.cell
+def _(canvas_len, model_1, processor, torch, train_rows):
+    eos = model_1.generation_config.eos_token_id or [1]
+    eos = eos[0] if isinstance(eos, (list, tuple)) else eos
+    tok = processor.tokenizer if hasattr(processor, "tokenizer") else processor
+    pad = tok.pad_token_id if tok.pad_token_id is not None else eos
+
+    def build_examples(rows):
+        out = []
+        for r in rows:
+            prompt_ids = processor.apply_chat_template(
+                [r["messages"][0]],
+                tokenize=True,
+                add_generation_prompt=True,
+                return_tensors="pt",
+            )[0]
+            ids = tok.encode(r["messages"][1]["content"], add_special_tokens=False)
+            content = ids + [eos]
+            n = len(content)
+            if n > canvas_len:
+                continue
+            x0 = torch.tensor(content + [pad] * (canvas_len - n), dtype=torch.long)
+            mask = torch.zeros(canvas_len, dtype=torch.bool)
+            mask[:n] = True
+            out.append((prompt_ids, x0, mask))
+        return out
+
+    examples = build_examples(train_rows)
+    print("usable examples:", len(examples))
+    return examples, tok
+
+
+@app.cell
+def _(canvas_len, examples, model_1, random, torch, vocab):
+    import time
+
+    # compute device, not a "meta" param (offloaded weights report device = meta -> indexing fails)
+    dev = next(
+        (p.device for p in model_1.parameters() if p.device.type != "meta"),
+        torch.device("cuda" if torch.cuda.is_available() else "cpu"),
+    )
+    STEPS, GRAD_ACCUM, LR, T_LO = (500, 4, 0.0001, 0.1)
+    model_1.config.use_cache = True  # full run in our report: 4000 steps, 8 GPUs
+    model_1.train()
+    opt = torch.optim.AdamW(
+        [p for p in model_1.parameters() if p.requires_grad],
+        lr=LR,
+        betas=(0.9, 0.95),
+        weight_decay=0.0,
+    )
+    sched = torch.optim.lr_scheduler.OneCycleLR(
+        opt, max_lr=LR, total_steps=STEPS, pct_start=0.03, anneal_strategy="cos"
+    )
+
+    def corrupt(x0):
+        t = random.uniform(T_LO, 1.0)  # noise level
+        xt = x0.to(dev).clone()
+        m = torch.rand(canvas_len, device=dev) < t
+        xt[m] = torch.randint(0, vocab, (canvas_len,), device=dev)[m]
+        return xt.unsqueeze(0)  # noise level
+
+    order = list(range(len(examples)))
+    ptr = 0
+    t0 = time.time()
+    opt.zero_grad(set_to_none=True)
+    for step in range(1, STEPS + 1):
+        step_loss = 0.0
+        for _ in range(GRAD_ACCUM):
+            if ptr >= len(order):
+                random.shuffle(order)
+                ptr = 0
+            prompt_ids, x0, lm = examples[order[ptr]]
+            ptr = ptr + 1
+            out = model_1(
+                input_ids=prompt_ids.unsqueeze(0).to(dev),
+                canvas_ids=corrupt(x0),
+                self_conditioning_logits=None,
+            )
+            logits = out.logits[0].float()  # [canvas_len, vocab]
+            m = lm.to(dev)  # [canvas_len, vocab]
+            loss = torch.nn.functional.cross_entropy(logits[m], x0.to(dev)[m])
+            (loss / GRAD_ACCUM).backward()
+            step_loss = step_loss + loss.item() / GRAD_ACCUM
+        torch.nn.utils.clip_grad_norm_(
+            [p for p in model_1.parameters() if p.requires_grad], 1.0
+        )
+        opt.step()
+        sched.step()
+        opt.zero_grad(set_to_none=True)
+        if step % 20 == 0:
+            print(
+                f"step {step:4d}/{STEPS} | loss {step_loss:.4f} | {time.time() - t0:.0f}s",
+                flush=True,
+            )
+    return (dev,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    <a name="Eval"></a>
+    # Evaluate: refinement is the point
+
+    We solve held-out puzzles by block-diffusion generation and score the **exact-solve rate**. Crucially we sweep the number of denoising steps: one shot (predict the grid once) is weak, but letting the model **revise over steps** is where it wins.
+    """)
+    return
+
+
+@app.cell
+def _(canvas_len, dev, eval_rows, model_1, processor, tok, torch):
+    import copy
+
+    def parse_grid(text):
+        ds = [int(ch) for ch in text if ch.isdigit()]
+        return ds[:81] if len(ds) >= 81 else None
+
+    def solve(prompt, steps):
+        ids = processor.apply_chat_template(
+            [{"role": "user", "content": prompt}],
+            tokenize=True,
+            add_generation_prompt=True,
+            return_tensors="pt",
+        ).to(dev)
+        gc = copy.deepcopy(model_1.generation_config)
+        gc.max_denoising_steps = steps
+        gc.max_new_tokens = canvas_len
+        torch.manual_seed(0)
+        with torch.no_grad():
+            out = model_1.generate(input_ids=ids, generation_config=gc)
+        seq = out.sequences[0, ids.shape[1] :]
+        return parse_grid(tok.decode(seq.tolist(), skip_special_tokens=True))
+
+    def eval_solve_rate(rows, steps, n=50):
+        solved = 0
+        for r in rows[:n]:
+            g = solve(r["messages"][0]["content"], steps)
+            solved = solved + (g is not None and g == [int(c) for c in r["solution"]])
+        return solved / min(n, len(rows))
+
+    model_1.eval()
+    for s in (1, 16, 64):
+        print(
+            f"{s:>2}-step exact-solve rate: {eval_solve_rate(eval_rows, s) * 100:.1f}%"
+        )
+    return (solve,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    In our full run (4000 steps, the report on the model card), the finetune takes the base model from **1.5% to 89.5%** exact-solve on medium puzzles, and the one-shot vs refined gap is **18% -> 89.5%** purely from revising over steps. An autoregressive LoRA baseline on the **same** data reaches only 14.5% and overwrites about a third of the given clues, because once it emits a cell it cannot reconcile it against constraints that appear later in the grid - the diffusion model keeps 100% of the givens.
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    <a name="Inference"></a>
+    # Solve a puzzle
+    """)
+    return
+
+
+@app.cell
+def _(eval_rows, solve):
+    puzzle = eval_rows[0]["messages"][0]["content"]
+    print(puzzle, "\n--- solved ---")
+    g = solve(puzzle, steps=64)
+    print(
+        "\n".join("".join(str(g[r * 9 + c]) for c in range(9)) for r in range(9))
+        if g
+        else "(no 81-digit grid)"
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    <a name="Save"></a>
+    # Save the LoRA
+    """)
+    return
+
+
+@app.cell
+def _(model_1, processor):
+    model_1.save_pretrained("diffusiongemma_lora")
+    processor.save_pretrained("diffusiongemma_lora")
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ### GGUF / llama.cpp
+
+    Prebuilt GGUFs are at [`unsloth/diffusiongemma-26B-A4B-it-GGUF`](https://huggingface.co/unsloth/diffusiongemma-26B-A4B-it-GGUF). DiffusionGemma needs the diffusiongemma build of llama.cpp and its `llama-diffusion-cli` runner (see that model card); the standard llama.cpp conversion does not cover this architecture yet.
+    And we're done! If you have any questions on Unsloth, we have a [Discord](https://discord.gg/unsloth) channel! If you find any bugs or want to keep updated with the latest LLM stuff, or need help, join projects etc, feel free to join our Discord!
+
+    Some other resources:
+    1. Looking to use Unsloth locally? Read our [Installation Guide](https://unsloth.ai/docs/get-started/install) for details on installing Unsloth on Windows, Docker, AMD, Intel GPUs.
+    2. Learn how to do Reinforcement Learning with our [RL Guide and notebooks](https://unsloth.ai/docs/get-started/reinforcement-learning-rl-guide).
+    3. Read our guides and notebooks for [Text-to-speech (TTS)](https://unsloth.ai/docs/basics/text-to-speech-tts-fine-tuning) and [vision](https://unsloth.ai/docs/basics/vision-fine-tuning) model support.
+    4. Explore our [LLM Tutorials Directory](https://unsloth.ai/docs/models/tutorials-how-to-fine-tune-and-run-llms) to find dedicated guides for each model.
+    5. Need help with Inference? Read our [Inference & Deployment page](https://unsloth.ai/docs/basics/inference-and-deployment) for details on using vLLM, llama.cpp, Ollama etc.
+
+    <div class="align-center">
+      <a href="https://unsloth.ai"><img src="https://github.com/unslothai/unsloth/raw/main/images/unsloth%20new%20logo.png" width="115"></a>
+      <a href="https://discord.gg/unsloth"><img src="https://github.com/unslothai/unsloth/raw/main/images/Discord.png" width="145"></a>
+      <a href="https://unsloth.ai/docs/"><img src="https://github.com/unslothai/unsloth/blob/main/images/documentation%20green%20button.png?raw=true" width="125"></a>
+
+      Join Discord if you need help + ⭐️ <i>Star us on <a href="https://github.com/unslothai/unsloth">Github</a> </i> ⭐️
+
+      This notebook and all Unsloth notebooks are licensed [LGPL-3.0](https://github.com/unslothai/notebooks?tab=LGPL-3.0-1-ov-file#readme)
+    </div>
+    """)
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/molab/Qwen3_MoE.py
+++ b/molab/Qwen3_MoE.py
@@ -351,7 +351,7 @@ def _(mo):
 @app.cell
 def _(dataset, max_seq_length, tokenizer):
     dataset["N"] = dataset["Messages"].apply(
-        lambda x: len(tokenizer.apply_chat_template(x)["input_ids"])
+        lambda x: len(tokenizer.apply_chat_template(x))
     )
     dataset_1 = dataset.loc[dataset["N"] <= max_seq_length / 2].copy()
     dataset_1.shape

--- a/molab/TinyQwen3_MoE.py
+++ b/molab/TinyQwen3_MoE.py
@@ -341,7 +341,7 @@ def _(mo):
 @app.cell
 def _(dataset, max_seq_length, tokenizer):
     dataset["N"] = dataset["Messages"].apply(
-        lambda x: len(tokenizer.apply_chat_template(x)["input_ids"])
+        lambda x: len(tokenizer.apply_chat_template(x))
     )
     dataset_1 = dataset.loc[dataset["N"] <= max_seq_length / 2].copy()
     dataset_1.shape

--- a/molab/generation_status.json
+++ b/molab/generation_status.json
@@ -7,6 +7,7 @@
   "Deepseek_OCR_(3B)-Eval": "ok",
   "Deepseek_OCR_(3B)-Evaluation": "ok",
   "Deepseek_OCR_2_(3B)": "ok",
+  "DiffusionGemma_(26B-A4B)-Sudoku": "ok",
   "ERNIE_4_5_21B_A3B_PT-Conversational": "ok",
   "ERNIE_4_5_VL_28B_A3B_PT_Vision": "ok",
   "EmbeddingGemma_(300M)": "ok",

--- a/nb/AMD-Qwen3_MoE.ipynb
+++ b/nb/AMD-Qwen3_MoE.ipynb
@@ -681,7 +681,7 @@
         }
       ],
       "source": [
-        "dataset[\"N\"] = dataset[\"Messages\"].apply(lambda x: len(tokenizer.apply_chat_template(x)['input_ids']))\n",
+        "dataset[\"N\"] = dataset[\"Messages\"].apply(lambda x: len(tokenizer.apply_chat_template(x)))\n",
         "\n",
         "dataset = dataset.loc[dataset[\"N\"] <= max_seq_length/2].copy()\n",
         "dataset.shape"

--- a/nb/AMD-TinyQwen3_MoE.ipynb
+++ b/nb/AMD-TinyQwen3_MoE.ipynb
@@ -642,7 +642,7 @@
         }
       ],
       "source": [
-        "dataset[\"N\"] = dataset[\"Messages\"].apply(lambda x: len(tokenizer.apply_chat_template(x)['input_ids']))\n",
+        "dataset[\"N\"] = dataset[\"Messages\"].apply(lambda x: len(tokenizer.apply_chat_template(x)))\n",
         "\n",
         "dataset = dataset.loc[dataset[\"N\"] <= max_seq_length/2].copy()\n",
         "dataset.shape"

--- a/nb/Qwen3_MoE.ipynb
+++ b/nb/Qwen3_MoE.ipynb
@@ -674,7 +674,7 @@
         }
       ],
       "source": [
-        "dataset[\"N\"] = dataset[\"Messages\"].apply(lambda x: len(tokenizer.apply_chat_template(x)['input_ids']))\n",
+        "dataset[\"N\"] = dataset[\"Messages\"].apply(lambda x: len(tokenizer.apply_chat_template(x)))\n",
         "\n",
         "dataset = dataset.loc[dataset[\"N\"] <= max_seq_length/2].copy()\n",
         "dataset.shape"

--- a/nb/TinyQwen3_MoE.ipynb
+++ b/nb/TinyQwen3_MoE.ipynb
@@ -635,7 +635,7 @@
         }
       ],
       "source": [
-        "dataset[\"N\"] = dataset[\"Messages\"].apply(lambda x: len(tokenizer.apply_chat_template(x)['input_ids']))\n",
+        "dataset[\"N\"] = dataset[\"Messages\"].apply(lambda x: len(tokenizer.apply_chat_template(x)))\n",
         "\n",
         "dataset = dataset.loc[dataset[\"N\"] <= max_seq_length/2].copy()\n",
         "dataset.shape"

--- a/python_scripts/AMD-Qwen3_MoE.py
+++ b/python_scripts/AMD-Qwen3_MoE.py
@@ -225,7 +225,7 @@ tokenizer.apply_chat_template(dataset["Messages"][0], tokenize = False)
 # In[14]:
 
 
-dataset["N"] = dataset["Messages"].apply(lambda x: len(tokenizer.apply_chat_template(x)['input_ids']))
+dataset["N"] = dataset["Messages"].apply(lambda x: len(tokenizer.apply_chat_template(x)))
 
 dataset = dataset.loc[dataset["N"] <= max_seq_length/2].copy()
 dataset.shape

--- a/python_scripts/AMD-TinyQwen3_MoE.py
+++ b/python_scripts/AMD-TinyQwen3_MoE.py
@@ -214,7 +214,7 @@ tokenizer.apply_chat_template(dataset["Messages"][0], tokenize = False)
 # In[12]:
 
 
-dataset["N"] = dataset["Messages"].apply(lambda x: len(tokenizer.apply_chat_template(x)['input_ids']))
+dataset["N"] = dataset["Messages"].apply(lambda x: len(tokenizer.apply_chat_template(x)))
 
 dataset = dataset.loc[dataset["N"] <= max_seq_length/2].copy()
 dataset.shape

--- a/python_scripts/DiffusionGemma_(26B-A4B)-Sudoku.py
+++ b/python_scripts/DiffusionGemma_(26B-A4B)-Sudoku.py
@@ -31,7 +31,7 @@
 
 # # ### Installation
 # 
-# # In[ ]:
+# # In[1]:
 # 
 # 
 # get_ipython().run_cell_magic('capture', '', 'import os, re\nif "COLAB_" not in "".join(os.environ.keys()):\n    !pip install unsloth  # local & cloud: pull deps, then upgrade unsloth + unsloth_zoo to main below\n    !pip install --no-deps --upgrade --force-reinstall git+https://github.com/unslothai/unsloth-zoo.git git+https://github.com/unslothai/unsloth.git\nelse:\n    import torch; v = re.match(r\'[\\d]{1,}\\.[\\d]{1,}\', str(torch.__version__)).group(0)\n    xformers = \'xformers==\' + {\'2.10\':\'0.0.34\',\'2.9\':\'0.0.33.post1\',\'2.8\':\'0.0.32.post2\'}.get(v, "0.0.34")\n    !pip install sentencepiece protobuf "datasets==4.3.0" "huggingface_hub>=0.34.0" hf_transfer\n    !pip install --no-deps bitsandbytes accelerate {xformers} peft trl triton\n    !pip install --no-deps --upgrade git+https://github.com/unslothai/unsloth-zoo.git git+https://github.com/unslothai/unsloth.git\n    !pip install --no-deps --upgrade "torchao>=0.16.0"\n!pip install --no-deps transformers==5.11.0 "tokenizers>=0.22.0,<=0.23.0"\nimport torch; torch._dynamo.config.recompile_limit = 64;\n')
@@ -43,7 +43,7 @@
 # 
 # DiffusionGemma needs a transformers build that ships the DiffusionGemma classes; `FastModel` auto-detects the diffusion architecture and routes to the transformers-only slow path.
 
-# In[ ]:
+# In[2]:
 
 
 from unsloth import FastModel
@@ -74,7 +74,7 @@ print("vocab", vocab, "| canvas", canvas_len)
 
 # We add LoRA adapters so we only train a few percent of the parameters. We target the attention and the dense MLP of the shared Gemma-4 backbone; the 128 fused MoE experts stay frozen.
 
-# In[ ]:
+# In[3]:
 
 
 model = FastModel.get_peft_model(
@@ -90,7 +90,7 @@ model = FastModel.get_peft_model(
 # 
 # We generate puzzle -> solution pairs procedurally, each with a **unique** solution (verified by a solver), so the target is the only correct answer. The 9x9 grid is written as 9 newline-separated rows of compact digits; the Gemma tokenizer splits digits individually, so every cell is exactly one token at a fixed canvas position. `0` marks an empty cell.
 
-# In[ ]:
+# In[4]:
 
 
 import random
@@ -172,7 +172,7 @@ print(len(train_rows), "train /", len(eval_rows), "eval puzzles")
 
 # A training example - the user message is the puzzle, the assistant message is the solved grid:
 
-# In[ ]:
+# In[5]:
 
 
 print(train_rows[0]["messages"][0]["content"])
@@ -185,7 +185,7 @@ print(train_rows[0]["messages"][1]["content"])
 # 
 # DiffusionGemma is not trained the autoregressive way (no `SFTTrainer`). Instead we use its own block-diffusion objective: pad the target solution to the 256-token canvas, **corrupt** the canvas by replacing each token with probability `t` by a random token, then ask the model to predict the clean grid. The loss is cross-entropy on the solution tokens plus the `eos` (the padding tail is ignored).
 
-# In[ ]:
+# In[6]:
 
 
 eos = (model.generation_config.eos_token_id or [1])
@@ -211,7 +211,7 @@ examples = build_examples(train_rows)
 print("usable examples:", len(examples))
 
 
-# In[ ]:
+# In[7]:
 
 
 import time
@@ -258,7 +258,7 @@ for step in range(1, STEPS + 1):
 # 
 # We solve held-out puzzles by block-diffusion generation and score the **exact-solve rate**. Crucially we sweep the number of denoising steps: one shot (predict the grid once) is weak, but letting the model **revise over steps** is where it wins.
 
-# In[ ]:
+# In[8]:
 
 
 import copy
@@ -295,7 +295,7 @@ for s in (1, 16, 64):
 # <a name="Inference"></a>
 # # Solve a puzzle
 
-# In[ ]:
+# In[9]:
 
 
 puzzle = eval_rows[0]["messages"][0]["content"]
@@ -307,7 +307,7 @@ print("\n".join("".join(str(g[r*9+c]) for c in range(9)) for r in range(9)) if g
 # <a name="Save"></a>
 # # Save the LoRA
 
-# In[ ]:
+# In[10]:
 
 
 model.save_pretrained("diffusiongemma_lora")

--- a/python_scripts/Qwen3_MoE.py
+++ b/python_scripts/Qwen3_MoE.py
@@ -218,7 +218,7 @@ tokenizer.apply_chat_template(dataset["Messages"][0], tokenize = False)
 # In[14]:
 
 
-dataset["N"] = dataset["Messages"].apply(lambda x: len(tokenizer.apply_chat_template(x)['input_ids']))
+dataset["N"] = dataset["Messages"].apply(lambda x: len(tokenizer.apply_chat_template(x)))
 
 dataset = dataset.loc[dataset["N"] <= max_seq_length/2].copy()
 dataset.shape

--- a/python_scripts/TinyQwen3_MoE.py
+++ b/python_scripts/TinyQwen3_MoE.py
@@ -207,7 +207,7 @@ tokenizer.apply_chat_template(dataset["Messages"][0], tokenize = False)
 # In[12]:
 
 
-dataset["N"] = dataset["Messages"].apply(lambda x: len(tokenizer.apply_chat_template(x)['input_ids']))
+dataset["N"] = dataset["Messages"].apply(lambda x: len(tokenizer.apply_chat_template(x)))
 
 dataset = dataset.loc[dataset["N"] <= max_seq_length/2].copy()
 dataset.shape

--- a/python_scripts/Unsloth_Studio.py
+++ b/python_scripts/Unsloth_Studio.py
@@ -1,30 +1,47 @@
 #!/usr/bin/env python
 # coding: utf-8
 
+# <a href="https://colab.research.google.com/github/unslothai/unsloth/blob/main/studio/Unsloth_Studio_Colab.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
+
+# To run this, press "*Runtime*" and press "*Run all*" on a **free** Tesla T4 Google Colab instance!
+# <div class="align-center">
+# <a href="https://unsloth.ai/"><img src="https://github.com/unslothai/unsloth/raw/main/images/unsloth%20new%20logo.png" width="115"></a>
+# <a href="https://discord.gg/unsloth"><img src="https://github.com/unslothai/unsloth/raw/main/images/Discord button.png" width="145"></a>
+# <a href="https://unsloth.ai/docs/"><img src="https://github.com/unslothai/unsloth/blob/main/images/documentation%20green%20button.png?raw=true" width="125"></a> Join Discord if you need help + ⭐ <i>Star us on <a href="https://github.com/unslothai/unsloth">Github</a> </i> ⭐
+# </div>
+# 
+# To install Unsloth Studio on your local device, follow [our guide](https://unsloth.ai/docs/new/unsloth-studio/install). Unsloth Studio is licensed [AGPL-3.0](https://github.com/unslothai/unsloth/blob/main/studio/LICENSE.AGPL-3.0).
+# 
+# ### Unsloth Studio
+# 
+# Train and run open models with [**Unsloth Studio**](https://unsloth.ai/docs/new/unsloth-studio/start). NEW! Installation should now only take 2 mins!
+# 
+# 
+# We are actively working on making Unsloth Studio install on Colab T4 GPUs faster.
+# 
+# [Features](https://unsloth.ai/docs/new/unsloth-studio#features) • [Quickstart](https://unsloth.ai/docs/new/unsloth-studio/start) • [Data Recipes](https://unsloth.ai/docs/new/unsloth-studio/data-recipe) • [Studio Chat](https://unsloth.ai/docs/new/unsloth-studio/chat) • [Export](https://unsloth.ai/docs/new/unsloth-studio/export)
+
+# <p align="left"><img src="https://github.com/unslothai/unsloth/raw/main/studio/frontend/public/studio%20github%20landscape%20colab%20display.png" width="600"></p>
+
+# ### Setup: Clone repo and run setup
+
 # In[ ]:
 
 
-# @title ↙️ Press ▶ to start 🦥 Unsloth Studio Chat for Llama-3.1 8b
+get_ipython().system('git clone --depth 1 --branch main https://github.com/unslothai/unsloth.git')
+get_ipython().run_line_magic('cd', '/content/unsloth')
+get_ipython().system('chmod +x studio/setup.sh && ./studio/setup.sh --local')
 
-# Unsloth Studio
-# Copyright (C) 2024-present the Unsloth AI team. All rights reserved.
 
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# ### Start Unsloth Studio
 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
+# In[ ]:
 
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-get_ipython().system('git clone https://github.com/unslothai/studio > /dev/null 2>&1')
-with open("studio/unsloth_studio/chat.py", "r") as chat_module:
-    code = chat_module.read()
-exec(code)
+
+import sys
+sys.path.insert(0, "/content/unsloth/studio/backend")
+from colab import start
+start()
 
 
 # And we're done! If you have any questions on Unsloth, we have a [Discord](https://discord.gg/unsloth) channel! If you find any bugs or want to keep updated with the latest LLM stuff, or need help, join projects etc, feel free to join our Discord!
@@ -43,5 +60,5 @@ exec(code)
 # 
 #   Join Discord if you need help + ⭐️ <i>Star us on <a href="https://github.com/unslothai/unsloth">Github</a> </i> ⭐️
 # 
-#   This notebook and all Unsloth notebooks are licensed [LGPL-3.0](https://github.com/unslothai/notebooks?tab=LGPL-3.0-1-ov-file#readme)
+#   <b>This notebook is licensed <a href="https://github.com/unslothai/unsloth/blob/main/studio/LICENSE.AGPL-3.0">AGPL-3.0</a></b>
 # </div>


### PR DESCRIPTION
The Qwen3 MoE reasoning notebooks compute per-example token length with:

```python
dataset["N"] = dataset["Messages"].apply(lambda x: len(tokenizer.apply_chat_template(x)["input_ids"]))
```

With the default `tokenize=True`, `apply_chat_template` returns a list of token ids, so indexing it with `["input_ids"]` raises `TypeError: list indices must be integers or slices, not str` and the data-prep cell fails before training ever starts.

The canonical GRPO notebooks already do this correctly:

```python
dataset["N"] = dataset["Messages"].apply(lambda x: len(tokenizer.apply_chat_template(x)))
```

This PR applies that fix to the four affected notebooks and their derived `python_scripts`:

- `nb/TinyQwen3_MoE.ipynb`, `nb/Qwen3_MoE.ipynb`, `nb/AMD-TinyQwen3_MoE.ipynb`, `nb/AMD-Qwen3_MoE.ipynb`
- matching `python_scripts/` copies

Verified by running `TinyQwen3_MoE` end-to-end on GPU after the change: the data-prep cell now succeeds and training completes.