### PR TITLE
Fix Gemma 4 audio inference dtype mismatch

### DIFF
--- a/nb/AMD-Gemma4_(E2B)-Text.ipynb
+++ b/nb/AMD-Gemma4_(E2B)-Text.ipynb
@@ -346,7 +346,7 @@
         "            tokenize = True,\n",
         "            return_dict = True,\n",
         "            return_tensors = \"pt\",\n",
-        "        ).to(\"cuda\"),\n",
+        "        ).to(\"cuda\", dtype = model.dtype),\n",
         "        max_new_tokens = max_new_tokens,\n",
         "        temperature = 1.0, top_p = 0.95, top_k = 64,\n",
         "        streamer = TextStreamer(tokenizer, skip_prompt = True)\n",


### PR DESCRIPTION
## Summary

- Cast multimodal processor outputs to `model.dtype` before Gemma 4 generation.
- Prevents the T4 audio path from mixing Float audio features with Half model tensors.

## Root cause

The notebook moved processor outputs to CUDA but did not normalize floating-point dtypes. On a T4, Gemma 4 runs in FP16 while audio features can remain FP32, causing `masked_scatter_` to fail with a Float/Half mismatch during multimodal fusion.

## Change

Updated the inference helper to use `.to("cuda", dtype=model.dtype)`. Integer token IDs remain integer tensors.

## Validation

- Notebook parses as valid JSON.
- `git diff --check` passes.
- Saved T4 notebook outputs show successful text, image, audio, and audio+image inference.
- Saved notebook contains zero error outputs.
- A fresh authenticated T4 rerun is still recommended for maintainer confirmation.

## Note

This patch was prepared with assistance from Codex.
