### PR TITLE
Pin torchcodec for Gemma 4 audio notebook

### DIFF
--- a/nb/Gemma4_(E2B)-Audio.ipynb
+++ b/nb/Gemma4_(E2B)-Audio.ipynb
@@ -65,7 +65,7 @@
         "id": "csoGx5FzqjUQ"
       },
       "outputs": [],
-      "source": "%%capture\nimport os, re\nif \"COLAB_\" not in \"\".join(os.environ.keys()):\n    !pip install unsloth  # Do this in local & cloud setups\nelse:\n    import torch; v = re.match(r'[\\d]{1,}\\.[\\d]{1,}', str(torch.__version__)).group(0)\n    xformers = 'xformers==' + {'2.10':'0.0.34','2.9':'0.0.33.post1','2.8':'0.0.32.post2'}.get(v, \"0.0.34\")\n    !pip install sentencepiece protobuf \"datasets==4.3.0\" \"huggingface_hub>=0.34.0\" hf_transfer\n    !pip install --no-deps unsloth_zoo bitsandbytes accelerate {xformers} peft trl triton unsloth\n    !pip install --no-deps --upgrade \"torchao>=0.16.0\"\n!pip install --no-deps transformers==5.5.0 \"tokenizers>=0.22.0,<=0.23.0\"\n!pip install torchcodec\nimport torch; torch._dynamo.config.recompile_limit = 64;"
+      "source": "%%capture\nimport os, re\nif \"COLAB_\" not in \"\".join(os.environ.keys()):\n    !pip install unsloth  # Do this in local & cloud setups\nelse:\n    import torch; v = re.match(r'[\\d]{1,}\\.[\\d]{1,}', str(torch.__version__)).group(0)\n    xformers = 'xformers==' + {'2.10':'0.0.34','2.9':'0.0.33.post1','2.8':'0.0.32.post2'}.get(v, \"0.0.34\")\n    !pip install sentencepiece protobuf \"datasets==4.3.0\" \"huggingface_hub>=0.34.0\" hf_transfer\n    !pip install --no-deps unsloth_zoo bitsandbytes accelerate {xformers} peft trl triton unsloth\n    !pip install --no-deps --upgrade \"torchao>=0.16.0\"\n!pip install --no-deps transformers==5.5.0 \"tokenizers>=0.22.0,<=0.23.0\"\n!pip install torchcodec==0.10.0\nimport torch; torch._dynamo.config.recompile_limit = 64;"
     },
     {
       "cell_type": "code",

--- a/python_scripts/Gemma4_(E2B)-Audio.py
+++ b/python_scripts/Gemma4_(E2B)-Audio.py
@@ -34,7 +34,7 @@
 # # In[1]:
 # 
 # 
-# get_ipython().run_cell_magic('capture', '', 'import os, re\nif "COLAB_" not in "".join(os.environ.keys()):\n    !pip install unsloth  # Do this in local & cloud setups\nelse:\n    import torch; v = re.match(r\'[\\d]{1,}\\.[\\d]{1,}\', str(torch.__version__)).group(0)\n    xformers = \'xformers==\' + {\'2.10\':\'0.0.34\',\'2.9\':\'0.0.33.post1\',\'2.8\':\'0.0.32.post2\'}.get(v, "0.0.34")\n    !pip install sentencepiece protobuf "datasets==4.3.0" "huggingface_hub>=0.34.0" hf_transfer\n    !pip install --no-deps unsloth_zoo bitsandbytes accelerate {xformers} peft trl triton unsloth\n    !pip install --no-deps --upgrade "torchao>=0.16.0"\n!pip install --no-deps transformers==5.5.0 "tokenizers>=0.22.0,<=0.23.0"\n!pip install torchcodec\nimport torch; torch._dynamo.config.recompile_limit = 64;\n')
+# get_ipython().run_cell_magic('capture', '', 'import os, re\nif "COLAB_" not in "".join(os.environ.keys()):\n    !pip install unsloth  # Do this in local & cloud setups\nelse:\n    import torch; v = re.match(r\'[\\d]{1,}\\.[\\d]{1,}\', str(torch.__version__)).group(0)\n    xformers = \'xformers==\' + {\'2.10\':\'0.0.34\',\'2.9\':\'0.0.33.post1\',\'2.8\':\'0.0.32.post2\'}.get(v, "0.0.34")\n    !pip install sentencepiece protobuf "datasets==4.3.0" "huggingface_hub>=0.34.0" hf_transfer\n    !pip install --no-deps unsloth_zoo bitsandbytes accelerate {xformers} peft trl triton unsloth\n    !pip install --no-deps --upgrade "torchao>=0.16.0"\n!pip install --no-deps transformers==5.5.0 "tokenizers>=0.22.0,<=0.23.0"\n!pip install torchcodec==0.10.0\nimport torch; torch._dynamo.config.recompile_limit = 64;\n')
 # 
 # 
 # # In[2]:


### PR DESCRIPTION
Closes #304

## What

Pin `torchcodec` to `0.10.0` in the Gemma 4 E2B audio notebook and its generated Python script.

## Why

Unsloth `2026.7.3` installs Torch `2.10.0+cu128`. The notebook currently installs unpinned `torchcodec`, allowing pip to select a newer release that rejects the Torch 2.10 installation during import. Issue #304 reports that `torchcodec==0.10.0` is the compatible release.

## How

Replace the unversioned install with `torchcodec==0.10.0` in both the source notebook and the generated script so Colab and script users resolve the same compatible dependency.

## Validation

- Notebook JSON validity test passed.
- Generated Python-script parity test passed.
- Python syntax compilation passed.
- `git diff --check` passed.
- Verified both artifacts contain exactly one `torchcodec==0.10.0` install.

## Note

This patch was prepared with assistance from Codex.
