### PR TITLE
fix(diffusiongemma): use decoder_input_ids instead of canvas_ids in Sudoku training loop

### DIFF
--- a/molab/DiffusionGemma_(26B-A4B)-Sudoku.py
+++ b/molab/DiffusionGemma_(26B-A4B)-Sudoku.py
@@ -374,7 +374,7 @@ def _(canvas_len, examples, model_1, random, torch, vocab):
             ptr = ptr + 1
             out = model_1(
                 input_ids=prompt_ids.unsqueeze(0).to(dev),
-                canvas_ids=corrupt(x0),
+                decoder_input_ids=corrupt(x0),
                 self_conditioning_logits=None,
             )
             logits = out.logits[0].float()  # [canvas_len, vocab]

--- a/nb/DiffusionGemma_(26B-A4B)-Sudoku.ipynb
+++ b/nb/DiffusionGemma_(26B-A4B)-Sudoku.ipynb
@@ -506,7 +506,7 @@
         "    for _ in range(GRAD_ACCUM):\n",
         "        if ptr >= len(order): random.shuffle(order); ptr = 0\n",
         "        prompt_ids, x0, lm = examples[order[ptr]]; ptr += 1\n",
-        "        out = model(input_ids = prompt_ids.unsqueeze(0).to(dev), canvas_ids = corrupt(x0),\n",
+        "        out = model(input_ids = prompt_ids.unsqueeze(0).to(dev), decoder_input_ids = corrupt(x0),\n",
         "                    self_conditioning_logits = None)\n",
         "        logits = out.logits[0].float()       # [canvas_len, vocab]\n",
         "        m = lm.to(dev)\n",

--- a/nb/Kaggle-DiffusionGemma_(26B-A4B)-Sudoku.ipynb
+++ b/nb/Kaggle-DiffusionGemma_(26B-A4B)-Sudoku.ipynb
@@ -304,7 +304,7 @@
     "    for _ in range(GRAD_ACCUM):\n",
     "        if ptr >= len(order): random.shuffle(order); ptr = 0\n",
     "        prompt_ids, x0, lm = examples[order[ptr]]; ptr += 1\n",
-    "        out = model(input_ids = prompt_ids.unsqueeze(0).to(dev), canvas_ids = corrupt(x0),\n",
+    "        out = model(input_ids = prompt_ids.unsqueeze(0).to(dev), decoder_input_ids = corrupt(x0),\n",
     "                    self_conditioning_logits = None)\n",
     "        logits = out.logits[0].float()       # [canvas_len, vocab]\n",
     "        m = lm.to(dev)\n",

--- a/original_template/DiffusionGemma_(26B-A4B)-Sudoku.ipynb
+++ b/original_template/DiffusionGemma_(26B-A4B)-Sudoku.ipynb
@@ -277,7 +277,7 @@
     "    for _ in range(GRAD_ACCUM):\n",
     "        if ptr >= len(order): random.shuffle(order); ptr = 0\n",
     "        prompt_ids, x0, lm = examples[order[ptr]]; ptr += 1\n",
-    "        out = model(input_ids=prompt_ids.unsqueeze(0).to(dev), canvas_ids=corrupt(x0),\n",
+    "        out = model(input_ids=prompt_ids.unsqueeze(0).to(dev), decoder_input_ids=corrupt(x0),\n",
     "                    self_conditioning_logits=None)\n",
     "        logits = out.logits[0].float()       # [canvas_len, vocab]\n",
     "        m = lm.to(dev)\n",

--- a/python_scripts/DiffusionGemma_(26B-A4B)-Sudoku.py
+++ b/python_scripts/DiffusionGemma_(26B-A4B)-Sudoku.py
@@ -241,7 +241,7 @@ for step in range(1, STEPS + 1):
     for _ in range(GRAD_ACCUM):
         if ptr >= len(order): random.shuffle(order); ptr = 0
         prompt_ids, x0, lm = examples[order[ptr]]; ptr += 1
-        out = model(input_ids = prompt_ids.unsqueeze(0).to(dev), canvas_ids = corrupt(x0),
+        out = model(input_ids = prompt_ids.unsqueeze(0).to(dev), decoder_input_ids = corrupt(x0),
                     self_conditioning_logits = None)
         logits = out.logits[0].float()       # [canvas_len, vocab]
         m = lm.to(dev)

--- a/python_scripts/Kaggle-DiffusionGemma_(26B-A4B)-Sudoku.py
+++ b/python_scripts/Kaggle-DiffusionGemma_(26B-A4B)-Sudoku.py
@@ -241,7 +241,7 @@ for step in range(1, STEPS + 1):
     for _ in range(GRAD_ACCUM):
         if ptr >= len(order): random.shuffle(order); ptr = 0
         prompt_ids, x0, lm = examples[order[ptr]]; ptr += 1
-        out = model(input_ids = prompt_ids.unsqueeze(0).to(dev), canvas_ids = corrupt(x0),
+        out = model(input_ids = prompt_ids.unsqueeze(0).to(dev), decoder_input_ids = corrupt(x0),
                     self_conditioning_logits = None)
         logits = out.logits[0].float()       # [canvas_len, vocab]
         m = lm.to(dev)


### PR DESCRIPTION
## Summary
The DiffusionGemma Sudoku fine-tuning notebook's training loop calls `model(input_ids=..., canvas_ids=corrupt(x0), self_conditioning_logits=None)`, but `DiffusionGemmaForBlockDiffusion.forward()` in `transformers` takes `decoder_input_ids` for the corrupted-canvas argument -- there is no `canvas_ids` parameter anywhere in the implementation.

## Root Cause
`canvas_ids` is not a recognized argument of `DiffusionGemmaForBlockDiffusion.forward()`, so it falls into the trailing `**kwargs` and is silently discarded (no `TypeError`). `decoder_input_ids` therefore stays `None`, and the model defaults to `torch.randint(...)` -- a fully random canvas on every training step -- instead of using the intended partial-noise-corrupted canvas from `corrupt(x0)`. This defeats the partial-noise curriculum the block-diffusion objective relies on.

Verified directly against the HF `transformers` source (`modeling_diffusion_gemma.py`): `forward()`'s signature takes `decoder_input_ids: torch.LongTensor | None = None`, and falls back to `torch.randint(...)` when it is `None`.

## Changes
Renamed `canvas_ids` -> `decoder_input_ids` in the training-loop call, in the source notebook and all five generated mirrors so they stay in sync:
- `original_template/DiffusionGemma_(26B-A4B)-Sudoku.ipynb` (source)
- `nb/DiffusionGemma_(26B-A4B)-Sudoku.ipynb`
- `nb/Kaggle-DiffusionGemma_(26B-A4B)-Sudoku.ipynb`
- `molab/DiffusionGemma_(26B-A4B)-Sudoku.py`
- `python_scripts/DiffusionGemma_(26B-A4B)-Sudoku.py`
- `python_scripts/Kaggle-DiffusionGemma_(26B-A4B)-Sudoku.py`

No other changes -- single-kwarg-name fix, 1-line diff per file.

## Testing
- Confirmed `canvas_ids` is now absent repo-wide (`grep -rln canvas_ids .` -> no results).
- Validated all three `.ipynb` files still parse as well-formed JSON after the edit.
- Verified against the live HF `transformers` source for `DiffusionGemmaForBlockDiffusion.forward()` that `decoder_input_ids` is the correct parameter name.

Fixes #7515
