### PR TITLE
Pin transformers 4.57.1 for LFM2.5-VL, which 4.56.2 cannot load

### DIFF
--- a/molab/LFM2.5_VL_(1.6B)-Vision.py
+++ b/molab/LFM2.5_VL_(1.6B)-Vision.py
@@ -11,7 +11,7 @@
 #     "protobuf",
 #     "sentencepiece",
 #     "torchao>=0.16.0",
-#     "transformers==4.56.2",
+#     "transformers==4.57.1",
 #     "triton>=3.2.0",
 #     "trl==0.22.2",
 #     "unsloth @ git+https://github.com/unslothai/unsloth",

--- a/nb/AMD-LFM2.5_VL_(1.6B)-Vision.ipynb
+++ b/nb/AMD-LFM2.5_VL_(1.6B)-Vision.ipynb
@@ -66,7 +66,7 @@
   {
    "cell_type": "code",
    "metadata": {},
-   "source": "!uv pip install --system -qqq sentencepiece protobuf \"datasets==4.3.0\" \"huggingface_hub>=0.34.0\" hf_transfer \"transformers==4.56.2\"\n!uv pip install --system -qqq --no-deps accelerate peft \"trl==0.22.2\"\n",
+   "source": "!uv pip install --system -qqq sentencepiece protobuf \"datasets==4.3.0\" \"huggingface_hub>=0.34.0\" hf_transfer \"transformers==4.57.1\"\n!uv pip install --system -qqq --no-deps accelerate peft \"trl==0.22.2\"\n",
    "execution_count": null,
    "outputs": []
   },

--- a/nb/LFM2.5_VL_(1.6B)-Vision.ipynb
+++ b/nb/LFM2.5_VL_(1.6B)-Vision.ipynb
@@ -63,7 +63,7 @@
     "id": "2sA8ZNSO3baO"
    },
    "outputs": [],
-   "source": "%%capture\nimport os, re\nif \"COLAB_\" not in \"\".join(os.environ.keys()):\n    !pip install unsloth  # Do this in local & cloud setups\nelse:\n    import torch; v = re.match(r'[\\d]{1,}\\.[\\d]{1,}', str(torch.__version__)).group(0)\n    xformers = 'xformers==' + {'2.10':'0.0.34','2.9':'0.0.33.post1','2.8':'0.0.32.post2'}.get(v, \"0.0.34\")\n    !pip install sentencepiece protobuf \"datasets==4.3.0\" \"huggingface_hub>=0.34.0\" hf_transfer\n    !pip install --no-deps unsloth_zoo bitsandbytes accelerate {xformers} peft trl triton unsloth\n    !pip install --no-deps --upgrade \"torchao>=0.16.0\"\n!pip install transformers==4.56.2\n!pip install --no-deps trl==0.22.2"
+   "source": "%%capture\nimport os, re\nif \"COLAB_\" not in \"\".join(os.environ.keys()):\n    !pip install unsloth  # Do this in local & cloud setups\nelse:\n    import torch; v = re.match(r'[\\d]{1,}\\.[\\d]{1,}', str(torch.__version__)).group(0)\n    xformers = 'xformers==' + {'2.10':'0.0.34','2.9':'0.0.33.post1','2.8':'0.0.32.post2'}.get(v, \"0.0.34\")\n    !pip install sentencepiece protobuf \"datasets==4.3.0\" \"huggingface_hub>=0.34.0\" hf_transfer\n    !pip install --no-deps unsloth_zoo bitsandbytes accelerate {xformers} peft trl triton unsloth\n    !pip install --no-deps --upgrade \"torchao>=0.16.0\"\n!pip install transformers==4.57.1\n!pip install --no-deps trl==0.22.2"
   },
   {
    "cell_type": "markdown",

--- a/python_scripts/AMD-LFM2.5_VL_(1.6B)-Vision.py
+++ b/python_scripts/AMD-LFM2.5_VL_(1.6B)-Vision.py
@@ -40,7 +40,7 @@
 # # In[ ]:
 # 
 # 
-# get_ipython().system('uv pip install --system -qqq sentencepiece protobuf "datasets==4.3.0" "huggingface_hub>=0.34.0" hf_transfer "transformers==4.56.2"')
+# get_ipython().system('uv pip install --system -qqq sentencepiece protobuf "datasets==4.3.0" "huggingface_hub>=0.34.0" hf_transfer "transformers==4.57.1"')
 # get_ipython().system('uv pip install --system -qqq --no-deps accelerate peft "trl==0.22.2"')
 # 
 # 

--- a/python_scripts/LFM2.5_VL_(1.6B)-Vision.py
+++ b/python_scripts/LFM2.5_VL_(1.6B)-Vision.py
@@ -36,7 +36,7 @@
 # # In[ ]:
 # 
 # 
-# get_ipython().run_cell_magic('capture', '', 'import os, re\nif "COLAB_" not in "".join(os.environ.keys()):\n    !pip install unsloth  # Do this in local & cloud setups\nelse:\n    import torch; v = re.match(r\'[\\d]{1,}\\.[\\d]{1,}\', str(torch.__version__)).group(0)\n    xformers = \'xformers==\' + {\'2.10\':\'0.0.34\',\'2.9\':\'0.0.33.post1\',\'2.8\':\'0.0.32.post2\'}.get(v, "0.0.34")\n    !pip install sentencepiece protobuf "datasets==4.3.0" "huggingface_hub>=0.34.0" hf_transfer\n    !pip install --no-deps unsloth_zoo bitsandbytes accelerate {xformers} peft trl triton unsloth\n    !pip install --no-deps --upgrade "torchao>=0.16.0"\n!pip install transformers==4.56.2\n!pip install --no-deps trl==0.22.2\n')
+# get_ipython().run_cell_magic('capture', '', 'import os, re\nif "COLAB_" not in "".join(os.environ.keys()):\n    !pip install unsloth  # Do this in local & cloud setups\nelse:\n    import torch; v = re.match(r\'[\\d]{1,}\\.[\\d]{1,}\', str(torch.__version__)).group(0)\n    xformers = \'xformers==\' + {\'2.10\':\'0.0.34\',\'2.9\':\'0.0.33.post1\',\'2.8\':\'0.0.32.post2\'}.get(v, "0.0.34")\n    !pip install sentencepiece protobuf "datasets==4.3.0" "huggingface_hub>=0.34.0" hf_transfer\n    !pip install --no-deps unsloth_zoo bitsandbytes accelerate {xformers} peft trl triton unsloth\n    !pip install --no-deps --upgrade "torchao>=0.16.0"\n!pip install transformers==4.57.1\n!pip install --no-deps trl==0.22.2\n')
 # 
 # 
 # # ### Unsloth

--- a/update_all_notebooks.py
+++ b/update_all_notebooks.py
@@ -736,6 +736,22 @@ installation_qwen3_vl_kaggle_content  = update_or_append_pip_install(
     "!pip install transformers==4.57.1",
 )
 
+# LFM2.5-VL is an `lfm2_vl` checkpoint, and that architecture landed in
+# transformers 4.57.0, so the canonical 4.56.2 cannot load it: the notebook
+# stopped at "`LiquidAI/LFM2.5-VL-1.6B` is not supported yet in
+# `transformers==4.56.2`". The text LFM2.5 notebooks are `lfm2`, which 4.56.2
+# does have, so only the vision one moves.
+installation_lfm2_vl_content = update_or_append_pip_install(
+    installation_content,
+    "transformers",
+    "!pip install transformers==4.57.1",
+)
+installation_lfm2_vl_kaggle_content = update_or_append_pip_install(
+    installation_kaggle_content,
+    "transformers",
+    "!pip install transformers==4.57.1",
+)
+
 installation_qwen3_5_content = """%%capture
 import os, importlib.util
 !pip install --upgrade -qqq uv
@@ -4309,6 +4325,13 @@ def update_notebook_sections(
                             else:
                                 installation = installation_deepseek_ocr_content
                                 
+                        # LFM2.5-VL INSTALLATION
+                        if is_path_contains_any(notebook_path.lower(), ["lfm2.5_vl"]):
+                            if is_path_contains_any(notebook_path.lower(), ["kaggle"]):
+                                installation = installation_lfm2_vl_kaggle_content
+                            else:
+                                installation = installation_lfm2_vl_content
+
                         # Qwen3VL INSTALLATION
                         if is_path_contains_any(notebook_path.lower(), ["qwen3"]) and is_vision:
                             if is_path_contains_any(notebook_path.lower(), ["kaggle"]):


### PR DESCRIPTION
## The bug

`LFM2.5_VL_(1.6B)-Vision` cannot load its own model:

```
ValueError: `LiquidAI/LFM2.5-VL-1.6B` is not supported yet in `transformers==4.56.2`.
Please update transformers via `pip install --upgrade transformers` and try again.
```

The checkpoint is an `lfm2_vl` architecture (`Lfm2VlForConditionalGeneration`),
and that landed in transformers 4.57.0. The generator hands this notebook the
canonical 4.56.2 install, so it stops at the model-loading cell and nothing
after it is reachable.

Found by running the 21 base notebooks that no sweep had ever executed, across
Colab T4 / T4-highRAM / L4 / A100-highmem.

## The fix

An install override pinning `transformers==4.57.1`, following the existing
`installation_qwen3_vl_content` next to it, which does the same thing for the
same reason.

Keyed on the `lfm2.5_vl` filename so only the vision notebook moves. The LFM2.5
text notebooks are `lfm2`, supported since 4.54, and I confirmed they stay on
4.56.2 rather than being dragged along.

## Verification

Re-ran the regenerated notebook on a Colab A100-highmem: **PASS**, where the
shipped notebook is a CONFIRMED_REGRESSION on the same hardware.

Tests: `6475 passed, 24 skipped`.

## Not fixed here

Two sibling notebooks, `LFM2.5_(1.2B)-Conversational` and
`LFM2.5_(1.2B)-Text_Completion`, failed in the same sweep with
`AttributeError: 'NoneType' object has no attribute 'endswith'`. That is a
transient fetch failure surfacing badly rather than a pin problem, and their
sibling `LFM2.5_(1.2B)-Translation` passed on the same install. unslothai/unsloth#8121
makes that error say what it is.

`LFM2.5_(1.2B)-GRPO` failed with `'Lfm2ForCausalLM' object has no attribute
'save_lora'`, which is a library-side gap, not a notebook one.