### PR TITLE
Reinstall torchaudio with torchvision in the sglang install cell

### DIFF
--- a/molab/Gemma3N_(2B)-Inference.py
+++ b/molab/Gemma3N_(2B)-Inference.py
@@ -3,6 +3,7 @@
 # dependencies = [
 #     "marimo",
 #     "sglang[all]==0.5.16",
+#     "torchaudio==2.11.0",
 #     "torchvision==0.26.0",
 # ]
 #

--- a/nb/Gemma3N_(2B)-Inference.ipynb
+++ b/nb/Gemma3N_(2B)-Inference.ipynb
@@ -57,7 +57,7 @@
     "id": "iQO6mdlThz35"
    },
    "outputs": [],
-   "source": "%%capture\n!pip install \"sglang[all]==0.5.16\"\n!pip install --force-reinstall --no-deps \"torchvision==0.26.0\""
+   "source": "%%capture\n!pip install \"sglang[all]==0.5.16\"\n!pip install --force-reinstall --no-deps \"torchvision==0.26.0\" \"torchaudio==2.11.0\""
   },
   {
    "cell_type": "markdown",

--- a/nb/Kaggle-Gemma3N_(2B)-Inference.ipynb
+++ b/nb/Kaggle-Gemma3N_(2B)-Inference.ipynb
@@ -57,7 +57,7 @@
     "id": "iQO6mdlThz35"
    },
    "outputs": [],
-   "source": "%%capture\n!pip install \"sglang[all]==0.5.16\"\n!pip install --force-reinstall --no-deps \"torchvision==0.26.0\""
+   "source": "%%capture\n!pip install \"sglang[all]==0.5.16\"\n!pip install --force-reinstall --no-deps \"torchvision==0.26.0\" \"torchaudio==2.11.0\""
   },
   {
    "cell_type": "markdown",

--- a/python_scripts/Gemma3N_(2B)-Inference.py
+++ b/python_scripts/Gemma3N_(2B)-Inference.py
@@ -34,7 +34,7 @@
 # # In[1]:
 # 
 # 
-# get_ipython().run_cell_magic('capture', '', '!pip install "sglang[all]==0.5.16"\n!pip install --force-reinstall --no-deps "torchvision==0.26.0"\n')
+# get_ipython().run_cell_magic('capture', '', '!pip install "sglang[all]==0.5.16"\n!pip install --force-reinstall --no-deps "torchvision==0.26.0" "torchaudio==2.11.0"\n')
 # 
 # 
 # # ### Unsloth

--- a/python_scripts/Kaggle-Gemma3N_(2B)-Inference.py
+++ b/python_scripts/Kaggle-Gemma3N_(2B)-Inference.py
@@ -34,7 +34,7 @@
 # # In[1]:
 # 
 # 
-# get_ipython().run_cell_magic('capture', '', '!pip install "sglang[all]==0.5.16"\n!pip install --force-reinstall --no-deps "torchvision==0.26.0"\n')
+# get_ipython().run_cell_magic('capture', '', '!pip install "sglang[all]==0.5.16"\n!pip install --force-reinstall --no-deps "torchvision==0.26.0" "torchaudio==2.11.0"\n')
 # 
 # 
 # # ### Unsloth

--- a/tests/test_sglang_torchvision_rebuild.py
+++ b/tests/test_sglang_torchvision_rebuild.py
@@ -16,13 +16,21 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Installing sglang replaces torch, so torchvision has to be replaced with it.
+"""Installing sglang replaces torch, so its companions have to be replaced too.
 
 sglang pins one exact torch (`torch==2.11.0` for 0.5.16), which resolves to the
-default PyPI wheel, a different CUDA build from the session's. torchvision is
-version-compatible either way, so pip leaves the old build in place and `import
-torchvision` fails on a CUDA mismatch. Only `--force-reinstall` replaces an
-already-satisfied requirement.
+default PyPI wheel, a different CUDA build from the session's. torchvision and
+torchaudio are version-compatible either way -- PEP 440 matches `==2.11.0`
+against a preinstalled `2.11.0+cu128` -- so pip leaves the old builds in place
+and importing them fails on a CUDA mismatch:
+
+  torchvision: "PyTorch has CUDA Version=13.0 and torchvision has CUDA
+               Version=12.8"
+  torchaudio:  "Detected that PyTorch and TorchAudio were compiled with
+               different CUDA versions"
+
+sglang imports both, so either one takes down `sglang.launch_server`. Only
+`--force-reinstall` replaces an already-satisfied requirement.
 """
 
 from __future__ import annotations
@@ -37,8 +45,10 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 NB_DIR = REPO_ROOT / "nb"
 
 _SGLANG_INSTALL = re.compile(r"^\s*!.*\bpip install\b.*\bsglang\b", re.MULTILINE)
-_TORCHVISION_INSTALL = re.compile(
-    r"^\s*!.*\bpip install\b.*\btorchvision\b.*$", re.MULTILINE)
+
+# The torch companions sglang drags along that ship compiled operators linked
+# against libtorch, so a CUDA build split is fatal at import.
+_COMPANIONS = ("torchvision", "torchaudio")
 
 
 def _cells_installing_sglang():
@@ -65,23 +75,27 @@ def test_some_notebook_installs_sglang():
     )
 
 
+@pytest.mark.parametrize("companion", _COMPANIONS)
 @pytest.mark.parametrize("cell_id,source", _CELLS, ids=[c for c, _ in _CELLS])
-def test_sglang_install_replaces_torchvision(cell_id, source):
-    lines = [line.strip() for line in _TORCHVISION_INSTALL.findall(source)]
+def test_sglang_install_replaces_torch_companion(cell_id, source, companion):
+    pattern = re.compile(
+        rf"^\s*!.*\bpip install\b.*\b{companion}\b.*$", re.MULTILINE
+    )
+    lines = [line.strip() for line in pattern.findall(source)]
     assert lines, (
         f"{cell_id} installs sglang, which pins one exact torch and so swaps "
-        f"the CUDA build under the session, but never reinstalls torchvision. "
-        f"`import torchvision` then fails on a CUDA version mismatch."
+        f"the CUDA build under the session, but never reinstalls {companion}. "
+        f"`import {companion}` then fails on a CUDA version mismatch."
     )
     forced = [line for line in lines if "--force-reinstall" in line]
     assert forced, (
-        f"{cell_id} reinstalls torchvision without --force-reinstall: "
+        f"{cell_id} reinstalls {companion} without --force-reinstall: "
         f"{lines}. The version constraint is already satisfied by the "
         f"pre-installed build, so pip does nothing and the mismatch survives."
     )
     for line in forced:
-        assert re.search(r"torchvision==\d", line), (
-            f"{cell_id} force-reinstalls torchvision unpinned: {line}. Pip "
-            f"would take the newest torchvision, which pairs with a newer "
+        assert re.search(rf"{companion}==\d", line), (
+            f"{cell_id} force-reinstalls {companion} unpinned: {line}. Pip "
+            f"would take the newest {companion}, which pairs with a newer "
             f"torch than sglang pinned."
         )

--- a/update_all_notebooks.py
+++ b/update_all_notebooks.py
@@ -795,9 +795,19 @@ installation_qwen3_5_kaggle_content = installation_qwen3_5_content
 # Version=12.8"). PEP 440 ignores a local label, so `torchvision==0.26.0` is
 # already satisfied by Colab's 0.26.0+cu128; force-reinstalling the same
 # version is what pulls it from the index the new torch came from.
+#
+# torchaudio is the same story and needs the same line. sglang 0.5.16 does pin
+# `torchaudio==2.11.0`, but that pin is already satisfied by Colab's
+# 2.11.0+cu128, so pip leaves the CUDA 12.8 build in place next to the new
+# CUDA 13.0 torch. torchaudio checks the two at import and raises
+# "Detected that PyTorch and TorchAudio were compiled with different CUDA
+# versions", and sglang imports torchaudio (srt/utils/common.py, the multimodal
+# processors, the realtime session), so launch_server never comes up. PyPI's
+# torchaudio 2.11.0 is itself a +cu130 build, so pulling it from the same index
+# as torch is all that is needed.
 installation_sglang_content = """%%capture
 !pip install "sglang[all]==0.5.16"
-!pip install --force-reinstall --no-deps "torchvision==0.26.0\""""
+!pip install --force-reinstall --no-deps "torchvision==0.26.0" "torchaudio==2.11.0\""""
 installation_sglang_kaggle_content = installation_sglang_content
 
 installation_deepseek_ocr_content = installation_content


### PR DESCRIPTION
### Problem

`Gemma3N_(2B)-Inference.ipynb` dies in its first serving cell on Colab:

```
RuntimeError: Detected that PyTorch and TorchAudio were compiled with different
CUDA versions. PyTorch has CUDA version 13.0 whereas TorchAudio has CUDA version 12.8.
```

`sglang.launch_server` never comes up, so every cell after it fails too.

### Root cause

Same mechanism as the `torchvision` line already sitting in that install cell, one package over.

sglang 0.5.16 pins `torch==2.11.0`, and the only PyPI wheel for that release is a CUDA 13.0 build, so installing sglang swaps the CUDA build under the session. It pins `torchaudio==2.11.0` as well, but PEP 440 matches a specifier with no local label against any local label, so the pin is already satisfied by the session's preinstalled `2.11.0+cu128` and pip leaves the CUDA 12.8 build in place.

torchaudio compares its own build CUDA against torch's at import and raises, and sglang imports torchaudio (`srt/utils/common.py`, the multimodal processors, the realtime session), so the server process exits during startup.

PyPI's `torchaudio 2.11.0` is itself a `+cu130` build (`torchaudio/version.py` inside the published wheel reads `__version__ = '2.11.0+cu130'`), so pulling it from the same index torch came from is all that is needed. Only `--force-reinstall` replaces an already-satisfied requirement.

### Change

`installation_sglang_content` in `update_all_notebooks.py`:

```
-!pip install --force-reinstall --no-deps "torchvision==0.26.0"
+!pip install --force-reinstall --no-deps "torchvision==0.26.0" "torchaudio==2.11.0"
```

plus the regenerated `nb/Gemma3N_(2B)-Inference.ipynb`, `nb/Kaggle-Gemma3N_(2B)-Inference.ipynb`, their `python_scripts/` mirrors and the molab dependency header. Those are the only notebooks in the repo whose install cells pull sglang.

### Test

`tests/test_sglang_torchvision_rebuild.py` already asserted the torchvision line; it is now parametrised over both torch companions. Before the change it fails on both sglang notebooks for `torchaudio`, after it passes.

Before:

```
FAILED test_sglang_install_replaces_torch_companion[Gemma3N_(2B)-Inference.ipynb:cell4-torchaudio]
FAILED test_sglang_install_replaces_torch_companion[Kaggle-Gemma3N_(2B)-Inference.ipynb:cell4-torchaudio]
2 failed, 3 passed
```

After:

```
5 passed
```

Full `pytest tests/` is 9496 passed with the same 6 failures main already has (`test_every_test_runs_in_ci`, `test_no_backgrounded_shell_command` x3, `test_saving_cell_names_a_bound_object` x2), verified against a clean checkout of the base commit.
