### PR TITLE
Give the Synthetic Data Hackathon notebook an install cell

### DIFF
--- a/.github/workflows/notebooks-tests-ci.yml
+++ b/.github/workflows/notebooks-tests-ci.yml
@@ -152,6 +152,12 @@ jobs:
         run: |
           python -m pytest tests/test_saving_cell_names_a_bound_object.py -q --tb=short
 
+      - name: tests/test_every_notebook_installs_its_stack.py
+        # Colab and Kaggle ship neither unsloth nor trl, so a notebook that
+        # imports them without an install cell cannot run at all.
+        run: |
+          python -m pytest tests/test_every_notebook_installs_its_stack.py -q --tb=short
+
       - name: tests/test_amd_git_main_unsloth_install.py
         # An AMD variant must keep the git-main unsloth upgrade its CUDA source
         # uses; the ignore list hid the drop from the parity validator.

--- a/molab/Synthetic_Data_Hackathon.py
+++ b/molab/Synthetic_Data_Hackathon.py
@@ -1,7 +1,21 @@
 # /// script
 # requires-python = ">=3.10,<3.14"
 # dependencies = [
+#     "accelerate",
+#     "bitsandbytes>=0.43.0",
+#     "datasets==4.3.0",
+#     "hf_transfer",
+#     "huggingface_hub>=0.34.0",
 #     "marimo",
+#     "peft",
+#     "protobuf",
+#     "sentencepiece",
+#     "torchao>=0.16.0",
+#     "transformers==4.56.2",
+#     "triton>=3.2.0",
+#     "trl==0.22.2",
+#     "unsloth @ git+https://github.com/unslothai/unsloth",
+#     "unsloth_zoo @ git+https://github.com/unslothai/unsloth-zoo",
 # ]
 #
 # [tool.uv]
@@ -76,11 +90,14 @@ def _():
     import random
     from pathlib import Path
 
-    _data_dir = "./logical_reasoning/data/final"
+    data_dir = "./logical_reasoning/data/final"  # Change this to your data directory
+    # ===== CONFIGURATION =====
+    # The same data/final/ the CLI writes with `save-as --format ft`.
     num_examples = 74  # how many puzzles to synthesise
-    seed = 3407
-    final_dir = Path(_data_dir)
+    seed = 3407  # how many puzzles to synthesise
+    final_dir = Path(data_dir)
     final_dir.mkdir(parents=True, exist_ok=True)
+    # Files already produced by the CLI are left untouched.
     interrupted = sorted(final_dir.glob("*.json.tmp"))
     existing = [] if interrupted else sorted(final_dir.glob("*.json"))
     NAMES = [
@@ -101,6 +118,7 @@ def _():
         "Olivia",
         "Peter",
     ]
+    # A leftover *.json.tmp means an earlier publish died, so the shards are partial.
     SYSTEM_PROMPT = "You are a careful logical reasoning assistant. Solve knight and knave puzzles by checking every possible assignment and explain your reasoning."
     PUZZLE_INTRO = "On this island every inhabitant is either a knight, who always tells the truth, or a knave, who always lies."
 
@@ -215,15 +233,17 @@ def _():
         staged = []
         for filename, shard in shards.items():
             tmp_path = final_dir / f"{filename}.tmp"
-            with open(tmp_path, "w") as _f:
-                json.dump(shard, _f, indent=2)
+            with open(tmp_path, "w") as f:
+                json.dump(shard, f, indent=2)
             staged.append((tmp_path, final_dir / filename, len(shard)))
         for tmp_path, final_path, count in staged:
             os.replace(tmp_path, final_path)
             print(f"Wrote {count} records to {final_path}")
         for leftover in interrupted:
             leftover.unlink(missing_ok=True)
-    print(f"Total ft files now in {final_dir}: {len(sorted(final_dir.glob('*.json')))}")
+    print(
+        f"Total ft files now in {final_dir}: {len(sorted(final_dir.glob('*.json')))}"
+    )
     return Path, json
 
 
@@ -255,17 +275,19 @@ def _(Path, json):
     import glob
     from datasets import Dataset
 
-    _data_dir = "./logical_reasoning/data/final"
-    data_path = Path(_data_dir)
+    data_dir_1 = "./logical_reasoning/data/final"
+    data_path = Path(data_dir_1)
     ft_files = sorted(glob.glob(str(data_path / "*.json")))
-    if not ft_files:
+    # ===== CONFIGURATION =====
+    if not ft_files:  # Change this to your data directory
         raise FileNotFoundError(
             f"No .json files found in {data_path.resolve()}. Run the synthetic data generation cell above, or produce the files yourself with `synthetic-data-kit save-as ./logical_reasoning/data/curated/ --format ft`, before running this cell."
         )
+    # ===== STEP 1: Find all FT files =====
     all_data = []
     for file_path in ft_files:
-        with open(file_path, "r") as _f:
-            ft_data = json.load(_f)
+        with open(file_path, "r") as f_1:
+            ft_data = json.load(f_1)
         for item in ft_data:
             if "messages" not in item:
                 continue
@@ -275,15 +297,18 @@ def _(Path, json):
                     conversation.append(
                         {"role": msg["role"], "content": msg["content"]}
                     )
+            # ===== STEP 2: Load and convert all files =====
             if len(conversation) > 0:
                 all_data.append({"conversations": conversation})
     print(f"\nTotal conversations: {len(all_data)} from {len(ft_files)} file(s)")
-    if not all_data:
+    if not all_data:  # Load the JSON file
         raise ValueError(
             f"Found {len(ft_files)} file(s) in {data_path.resolve()} but none of them contained a usable record. Every record needs a `messages` list with at least one user or assistant turn, which is what the `ft` format produces. Check the files before training on an empty set."
         )
     dataset = Dataset.from_list(all_data)
-    print(json.dumps(dataset[0], indent=2))
+    print(
+        json.dumps(dataset[0], indent=2)
+    )
     return (dataset,)
 
 

--- a/nb/Synthetic_Data_Hackathon.ipynb
+++ b/nb/Synthetic_Data_Hackathon.ipynb
@@ -10,6 +10,20 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Installation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "%%capture\nimport os, re\nif \"COLAB_\" not in \"\".join(os.environ.keys()):\n    !pip install unsloth  # Do this in local & cloud setups\nelse:\n    import torch; v = re.match(r'[\\d]{1,}\\.[\\d]{1,}', str(torch.__version__)).group(0)\n    xformers = 'xformers==' + {'2.10':'0.0.34','2.9':'0.0.33.post1','2.8':'0.0.32.post2'}.get(v, \"0.0.34\")\n    !pip install sentencepiece protobuf \"datasets==4.3.0\" \"huggingface_hub>=0.34.0\" hf_transfer\n    !pip install --no-deps unsloth_zoo bitsandbytes accelerate {xformers} peft trl triton unsloth\n    !pip install --no-deps --upgrade \"torchao>=0.16.0\"\n!pip install transformers==4.56.2\n!pip install --no-deps trl==0.22.2"
+  },
+  {
+   "cell_type": "markdown",
    "id": "988e8e0a-e95f-4f46-840f-944bd7335754",
    "metadata": {},
    "source": [

--- a/python_scripts/Synthetic_Data_Hackathon.py
+++ b/python_scripts/Synthetic_Data_Hackathon.py
@@ -3,6 +3,14 @@
 
 # <h1 align='center'>Synthetic Data Generation and Unsloth Tutorial</h1>
 
+# ### Installation
+
+# In[ ]:
+
+
+get_ipython().run_cell_magic('capture', '', 'import os, re\nif "COLAB_" not in "".join(os.environ.keys()):\n    !pip install unsloth  # Do this in local & cloud setups\nelse:\n    import torch; v = re.match(r\'[\\d]{1,}\\.[\\d]{1,}\', str(torch.__version__)).group(0)\n    xformers = \'xformers==\' + {\'2.10\':\'0.0.34\',\'2.9\':\'0.0.33.post1\',\'2.8\':\'0.0.32.post2\'}.get(v, "0.0.34")\n    !pip install sentencepiece protobuf "datasets==4.3.0" "huggingface_hub>=0.34.0" hf_transfer\n    !pip install --no-deps unsloth_zoo bitsandbytes accelerate {xformers} peft trl triton unsloth\n    !pip install --no-deps --upgrade "torchao>=0.16.0"\n!pip install transformers==4.56.2\n!pip install --no-deps trl==0.22.2\n')
+
+
 # ## Synthetic Data Generation
 # 
 # In this section, we use the CLI from synthetic-data-kit to generate datasets

--- a/tests/test_every_notebook_installs_its_stack.py
+++ b/tests/test_every_notebook_installs_its_stack.py
@@ -1,0 +1,163 @@
+# Unsloth Notebooks - Notebooks for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+"""A notebook that imports the stack has to install it first.
+
+Colab and Kaggle ship neither unsloth nor trl, and they ship whatever
+transformers their base image happens to carry that week. So a notebook under
+`nb/` that says `from unsloth import FastLanguageModel` and never runs a
+`pip install` cannot run anywhere except a machine that was already set up by
+hand.
+
+`Synthetic_Data_Hackathon.ipynb` shipped in that state and died on
+
+    ModuleNotFoundError: No module named 'trl'
+
+raised from inside `unsloth/models/_utils.py`, on a Colab whose base image had
+resolved transformers to 5.13.1. It is one of the notebooks generation skips
+(`DONT_UPDATE_EXCEPTIONS`), so the install cell every other notebook receives
+from `update_all_notebooks.py` was never written into it, and its own AMD
+variant did have one, because the AMD generator injects the ROCm install cell
+itself. Nothing compared the two.
+
+The check is deliberately coarse -- SOME pip install line, BEFORE the first
+import of the stack -- because the pinning of individual packages is already
+covered by `test_notebook_pin_consistency.py`. What was missing was a check
+that there is anything there at all.
+
+Scoped to `nb/` and `kaggle/`, the trees a reader opens. `original_template/`
+carries `# Placeholder` cells that the generator turns into the install cells,
+so it has nothing to assert against.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+NB_DIRS = (REPO_ROOT / "nb", REPO_ROOT / "kaggle")
+
+# Everything a notebook must not assume is already present. torch is left out
+# on purpose: Colab and Kaggle really do ship it, and every install cell here
+# reads its version rather than installing it.
+STACK = ("unsloth", "unsloth_zoo", "trl", "transformers", "peft")
+
+_IMPORT = re.compile(
+    r"^\s*(?:from|import)\s+(" + "|".join(STACK) + r")\b", re.MULTILINE)
+# `!pip install`, `%pip install`, `!uv pip install --system`, and the same
+# lines inside a `%%bash` cell.
+_INSTALL = re.compile(r"(?:uv\s+)?pip\s+install\b")
+
+
+def _first_code_cell(path: Path, pattern: re.Pattern):
+    """Index of the first code cell matching `pattern`, or None."""
+    notebook = json.loads(path.read_text(encoding="utf-8"))
+    for index, cell in enumerate(notebook.get("cells", [])):
+        if cell.get("cell_type") != "code":
+            continue
+        if pattern.search("".join(cell.get("source", []))):
+            return index
+    return None
+
+
+def _imported_names(path: Path) -> set[str]:
+    notebook = json.loads(path.read_text(encoding="utf-8"))
+    code = "\n".join(
+        "".join(cell.get("source", []))
+        for cell in notebook.get("cells", [])
+        if cell.get("cell_type") == "code")
+    return set(_IMPORT.findall(code))
+
+
+def _notebooks():
+    found = []
+    for directory in NB_DIRS:
+        found += sorted(directory.glob("*.ipynb"))
+    return found
+
+
+@pytest.mark.parametrize(
+    "path", _notebooks(), ids=lambda p: f"{p.parent.name}/{p.name}")
+def test_a_notebook_that_imports_the_stack_installs_it(path):
+    imported = _imported_names(path)
+    if not imported:
+        return          # a notebook that imports none of it needs no cell
+    install_at = _first_code_cell(path, _INSTALL)
+    assert install_at is not None, (
+        f"{path.relative_to(REPO_ROOT)} imports "
+        + ", ".join(sorted(imported))
+        + " but has no pip install cell anywhere, so on Colab or Kaggle it "
+          "stops on ModuleNotFoundError."
+    )
+    import_at = _first_code_cell(path, _IMPORT)
+    assert install_at < import_at, (
+        f"{path.relative_to(REPO_ROOT)} imports the stack in cell {import_at} "
+        f"but does not install it until cell {install_at}; the import runs "
+        "first and fails."
+    )
+
+
+def test_the_suite_is_looking_at_the_notebooks():
+    """A glob that stopped matching would leave every case above vacuous."""
+    assert len(_notebooks()) > 400
+
+
+def test_the_gate_would_have_caught_the_notebook_that_shipped_without_a_cell(
+        tmp_path):
+    """The exact shape of the bug: imports, no install line."""
+    notebook = tmp_path / "x.ipynb"
+    notebook.write_text(json.dumps({"cells": [
+        {"cell_type": "markdown", "metadata": {}, "source": ["# title"]},
+        {"cell_type": "code", "metadata": {}, "outputs": [],
+         "execution_count": None,
+         "source": ["from unsloth import FastLanguageModel\n",
+                    "from trl import SFTTrainer\n"]},
+    ]}), encoding="utf-8")
+    assert _imported_names(notebook) == {"unsloth", "trl"}
+    assert _first_code_cell(notebook, _INSTALL) is None
+
+
+def test_an_install_cell_ahead_of_the_import_satisfies_the_gate(tmp_path):
+    notebook = tmp_path / "x.ipynb"
+    notebook.write_text(json.dumps({"cells": [
+        {"cell_type": "code", "metadata": {}, "outputs": [],
+         "execution_count": None,
+         "source": ["%%capture\n", "!pip install unsloth\n"]},
+        {"cell_type": "code", "metadata": {}, "outputs": [],
+         "execution_count": None,
+         "source": ["from unsloth import FastLanguageModel\n"]},
+    ]}), encoding="utf-8")
+    assert _first_code_cell(notebook, _INSTALL) == 0
+    assert _first_code_cell(notebook, _IMPORT) == 1
+
+
+@pytest.mark.parametrize("line", [
+    "!pip install unsloth",
+    "%pip install unsloth",
+    "!uv pip install -qqq unsloth",
+    "uv pip install --system -U unsloth",
+    "    pip install bitsandbytes",
+], ids=["bang", "magic", "uv", "uv-system-bash", "bare-in-bash"])
+def test_the_ways_these_notebooks_really_install_all_count(line):
+    assert _INSTALL.search(line)
+
+
+@pytest.mark.parametrize("line", [
+    "# pip installation is described at unsloth.ai/docs",
+    "print('run pip freeze to see versions')",
+], ids=["prose", "unrelated"])
+def test_prose_about_pip_is_not_an_install_line(line):
+    assert not _INSTALL.search(line)


### PR DESCRIPTION
### The bug

`nb/Synthetic_Data_Hackathon.ipynb` has no install cell. Not a wrong one, none
at all. It goes from its title straight into

```python
from unsloth import FastLanguageModel
from unsloth.chat_templates import get_chat_template, standardize_sharegpt, train_on_responses_only
from trl import SFTConfig, SFTTrainer
```

Colab ships neither unsloth nor trl, so the notebook ran against the base image
and stopped with

```
ModuleNotFoundError: No module named 'trl'
```

raised from `unsloth/models/_utils.py`, with transformers left at whatever the
image carried that week (5.13.1 on the run that caught this) rather than the
4.56.2 the rest of the repo pins.

It is one of four notebooks in `nb/` with no `pip install` line anywhere; the
other three are the Unsloth Studio notebooks, which import none of the stack.

### Why it went unnoticed

The notebook is in `DONT_UPDATE_EXCEPTIONS`, so `nb/` is its source and
generation never wrote the install cell every other notebook receives. Its own
AMD variant does have one, because the AMD generator injects the ROCm install
cell itself regardless of what the CUDA source contains. So the two trees
disagreed and nothing compared them.

### The fix

The standard Colab install cell, verbatim, so the pins match the rest of the
repo (`transformers==4.56.2`, `trl==0.22.2`), placed after the title and ahead
of the first cell that needs `datasets`. `nb/` is the source here, so this is a
hand edit to `nb/`; `python_scripts/` and `molab/` are regenerator output.

The AMD variant is unchanged, which is the expected result: it already had its
own install cells.

### Regression test

`tests/test_every_notebook_installs_its_stack.py` fails on the notebook as it
is today and passes after the change. Every notebook in `nb/` and `kaggle/`
that imports unsloth, unsloth_zoo, trl, transformers or peft must run a
`pip install` line, in an earlier cell than that import.

The check is deliberately coarse. Which versions get pinned is already
`test_notebook_pin_consistency.py`'s job; what was missing here was any install
line at all. It recognises `!pip`, `%pip`, `!uv pip` and the bare `pip install`
lines inside the AMD `%%bash` cells, and does not count prose that merely
contains the word.

### Test results

```
python -m pytest tests/ -q --ignore=tests/security
9964 passed, 164 skipped in 225.79s
```

Before the change, the same run reports:

```
FAILED test_a_notebook_that_imports_the_stack_installs_it[nb/Synthetic_Data_Hackathon.ipynb]
  nb/Synthetic_Data_Hackathon.ipynb imports transformers, trl, unsloth but has no
  pip install cell anywhere, so on Colab or Kaggle it stops on ModuleNotFoundError.
```

### Not verified

The notebook was not executed on Colab or on a GPU, so I have not confirmed the
run completes end to end, only that the import that stopped it can now succeed.
The install cell is the one the other 400-odd notebooks in this repo already
use, unmodified.