### PR TITLE
Install transformers main with --no-deps in Falcon H1, so numpy survives

### DIFF
--- a/.github/workflows/notebooks-tests-ci.yml
+++ b/.github/workflows/notebooks-tests-ci.yml
@@ -172,14 +172,6 @@ jobs:
         run: |
           python -m pytest tests/test_transformers_main_no_deps_floors.py -q --tb=short
 
-      - name: tests/test_force_reinstall_does_not_replace_numpy.py
-        # The other half of the floors gate above: that one matches on
-        # --no-deps and so cannot see a cell that never passed the flag.
-        # Without it pip re-resolves numpy, which Colab has already imported,
-        # and Unsloth refuses to run on a kernel holding the old C extension.
-        run: |
-          python -m pytest tests/test_force_reinstall_does_not_replace_numpy.py -q --tb=short
-
       - name: tests/test_every_test_runs_in_ci.py
         run: |
           python -m pytest tests/test_every_test_runs_in_ci.py -q --tb=short
@@ -187,6 +179,14 @@ jobs:
       - name: tests/test_qat_numpy_pin.py
         run: |
           python -m pytest tests/test_qat_numpy_pin.py -q --tb=short
+
+      - name: tests/test_force_reinstall_does_not_replace_numpy.py
+        # Same "numpy was upgraded mid-session" error as the QAT pin above,
+        # reached through a different install line. It is also the other half
+        # of the transformers-main floors gate, which matches on --no-deps and
+        # so cannot see a cell that never passed the flag.
+        run: |
+          python -m pytest tests/test_force_reinstall_does_not_replace_numpy.py -q --tb=short
 
       - name: tests/test_no_backgrounded_shell_launch.py
         # nbclient + ipykernel so the live-kernel case actually runs. Without

--- a/.github/workflows/notebooks-tests-ci.yml
+++ b/.github/workflows/notebooks-tests-ci.yml
@@ -172,13 +172,13 @@ jobs:
         run: |
           python -m pytest tests/test_transformers_main_no_deps_floors.py -q --tb=short
 
-      - name: tests/test_transformers_main_installs_use_no_deps.py
+      - name: tests/test_force_reinstall_does_not_replace_numpy.py
         # The other half of the floors gate above: that one matches on
         # --no-deps and so cannot see a cell that never passed the flag.
-        # Without it pip re-resolves numpy, which the kernel has already
-        # imported, and Unsloth refuses to run.
+        # Without it pip re-resolves numpy, which Colab has already imported,
+        # and Unsloth refuses to run on a kernel holding the old C extension.
         run: |
-          python -m pytest tests/test_transformers_main_installs_use_no_deps.py -q --tb=short
+          python -m pytest tests/test_force_reinstall_does_not_replace_numpy.py -q --tb=short
 
       - name: tests/test_every_test_runs_in_ci.py
         run: |

--- a/.github/workflows/notebooks-tests-ci.yml
+++ b/.github/workflows/notebooks-tests-ci.yml
@@ -172,6 +172,14 @@ jobs:
         run: |
           python -m pytest tests/test_transformers_main_no_deps_floors.py -q --tb=short
 
+      - name: tests/test_transformers_main_installs_use_no_deps.py
+        # The other half of the floors gate above: that one matches on
+        # --no-deps and so cannot see a cell that never passed the flag.
+        # Without it pip re-resolves numpy, which the kernel has already
+        # imported, and Unsloth refuses to run.
+        run: |
+          python -m pytest tests/test_transformers_main_installs_use_no_deps.py -q --tb=short
+
       - name: tests/test_every_test_runs_in_ci.py
         run: |
           python -m pytest tests/test_every_test_runs_in_ci.py -q --tb=short

--- a/molab/Falcon_H1-Alpaca.py
+++ b/molab/Falcon_H1-Alpaca.py
@@ -2,8 +2,11 @@
 # requires-python = ">=3.10,<3.14"
 # dependencies = [
 #     "causal-conv1d @ git+https://github.com/Dao-AILab/causal-conv1d.git@main",
+#     "huggingface_hub>=1.5.0,<2.0",
 #     "mamba @ git+https://github.com/state-spaces/mamba.git@main",
 #     "marimo",
+#     "safetensors>=0.8.0",
+#     "tokenizers>=0.22.0,<=0.23.0",
 #     "torchao>=0.16.0",
 #     "transformers @ git+https://github.com/huggingface/transformers.git",
 #     "unsloth @ git+https://github.com/unslothai/unsloth",
@@ -74,6 +77,32 @@ def _():
     # Get latest Unsloth
     #! pip uninstall unsloth -y
     subprocess.call(["pip", "uninstall", "unsloth", "-y"])
+
+    return
+
+
+@app.cell
+def _():
+    # Need main branch for Falcon H1 models
+    # --no-deps above is deliberate. Without it pip re-resolves the entire tree
+    # rather than only what is missing: measured, `--force-reinstall` on this URL
+    # lands numpy 2.5.2 on top of the numpy 2.0.2 molab boots with. molab has
+    # already imported numpy before cell 1 runs, and numpy is a C extension that
+    # cannot be swapped under a live kernel, so the next Unsloth import stops with
+    # "numpy was upgraded mid-session ... Please restart your runtime/kernel" and
+    # no later cell can repair it. Same failure the QAT install cell pins numpy
+    # against.
+    # The cost of --no-deps is that pip enforces nothing transformers main
+    # declares. It only warns, and still exits 0, so every requirement it lists is
+    # a delayed import error waiting to happen. The rule, rather than adding one
+    # more floor each time one surfaces: take install_requires from transformers
+    # main setup.py and raise every entry the base images fall short of. Both
+    # images reach this cell on huggingface_hub 0.36.2 and Kaggle ships
+    # safetensors 0.7.0, so those two need raising; tokenizers 0.22.2 already sits
+    # inside its window and is pinned only to hold it under the 0.23.0 cap that
+    # nothing else here enforces.
+    # tests/test_transformers_main_no_deps_floors.py holds this line to that rule,
+    # and tests/test_transformers_main_installs_use_no_deps.py holds the flag.
 
     return
 

--- a/nb/AMD-Falcon_H1-Alpaca.ipynb
+++ b/nb/AMD-Falcon_H1-Alpaca.ipynb
@@ -31,7 +31,7 @@
   {
    "cell_type": "code",
    "metadata": {},
-   "source": "!uv pip install --system -qqq --upgrade --force-reinstall --no-deps git+https://github.com/unslothai/unsloth.git@main git+https://github.com/unslothai/unsloth-zoo.git\n!uv pip install --system -qqq sentencepiece protobuf \"datasets==4.3.0\" \"huggingface_hub>=0.34.0\" hf_transfer\n!uv pip install --system -qqq --no-deps accelerate peft \"trl==0.22.2\"\n!uv pip install --system -qqq --upgrade --force-reinstall git+https://github.com/huggingface/transformers.git\n!uv pip install --system -qqq --no-build-isolation git+https://github.com/Dao-AILab/causal-conv1d.git@main git+https://github.com/state-spaces/mamba.git@main\n",
+   "source": "!uv pip install --system -qqq --upgrade --force-reinstall --no-deps git+https://github.com/unslothai/unsloth.git@main git+https://github.com/unslothai/unsloth-zoo.git\n!uv pip install --system -qqq sentencepiece protobuf \"datasets==4.3.0\" hf_transfer \"huggingface_hub>=1.5.0,<2.0\" \"safetensors>=0.8.0\"\n!uv pip install --system -qqq --no-deps accelerate peft \"trl==0.22.2\" git+https://github.com/huggingface/transformers.git\n!uv pip install --system -qqq --no-build-isolation git+https://github.com/Dao-AILab/causal-conv1d.git@main git+https://github.com/state-spaces/mamba.git@main\n",
    "execution_count": null,
    "outputs": []
   },

--- a/nb/Falcon_H1-Alpaca.ipynb
+++ b/nb/Falcon_H1-Alpaca.ipynb
@@ -67,7 +67,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --force-reinstall git+https://github.com/huggingface/transformers.git "
+    "!pip install --no-deps git+https://github.com/huggingface/transformers.git # Need main branch for Falcon H1 models\n",
+    "# --no-deps above is deliberate. Without it pip re-resolves the entire tree\n",
+    "# rather than only what is missing: measured, `--force-reinstall` on this URL\n",
+    "# lands numpy 2.5.2 on top of the numpy 2.0.2 Colab boots with. Colab has\n",
+    "# already imported numpy before cell 1 runs, and numpy is a C extension that\n",
+    "# cannot be swapped under a live kernel, so the next Unsloth import stops with\n",
+    "# \"numpy was upgraded mid-session ... Please restart your runtime/kernel\" and\n",
+    "# no later cell can repair it. Same failure the QAT install cell pins numpy\n",
+    "# against.\n",
+    "# The cost of --no-deps is that pip enforces nothing transformers main\n",
+    "# declares. It only warns, and still exits 0, so every requirement it lists is\n",
+    "# a delayed import error waiting to happen. The rule, rather than adding one\n",
+    "# more floor each time one surfaces: take install_requires from transformers\n",
+    "# main setup.py and raise every entry the base images fall short of. Both\n",
+    "# images reach this cell on huggingface_hub 0.36.2 and Kaggle ships\n",
+    "# safetensors 0.7.0, so those two need raising; tokenizers 0.22.2 already sits\n",
+    "# inside its window and is pinned only to hold it under the 0.23.0 cap that\n",
+    "# nothing else here enforces.\n",
+    "# tests/test_transformers_main_no_deps_floors.py holds this line to that rule,\n",
+    "# and tests/test_transformers_main_installs_use_no_deps.py holds the flag.\n",
+    "!pip install \"huggingface_hub>=1.5.0,<2.0\" \"safetensors>=0.8.0\" \"tokenizers>=0.22.0,<=0.23.0\""
    ]
   },
   {

--- a/python_scripts/AMD-Falcon_H1-Alpaca.py
+++ b/python_scripts/AMD-Falcon_H1-Alpaca.py
@@ -22,9 +22,8 @@ get_ipython().run_cell_magic('bash', '', 'python -m pip install -qU uv --root-us
 
 
 get_ipython().system('uv pip install --system -qqq --upgrade --force-reinstall --no-deps git+https://github.com/unslothai/unsloth.git@main git+https://github.com/unslothai/unsloth-zoo.git')
-get_ipython().system('uv pip install --system -qqq sentencepiece protobuf "datasets==4.3.0" "huggingface_hub>=0.34.0" hf_transfer')
-get_ipython().system('uv pip install --system -qqq --no-deps accelerate peft "trl==0.22.2"')
-get_ipython().system('uv pip install --system -qqq --upgrade --force-reinstall git+https://github.com/huggingface/transformers.git')
+get_ipython().system('uv pip install --system -qqq sentencepiece protobuf "datasets==4.3.0" hf_transfer "huggingface_hub>=1.5.0,<2.0" "safetensors>=0.8.0"')
+get_ipython().system('uv pip install --system -qqq --no-deps accelerate peft "trl==0.22.2" git+https://github.com/huggingface/transformers.git')
 get_ipython().system('uv pip install --system -qqq --no-build-isolation git+https://github.com/Dao-AILab/causal-conv1d.git@main git+https://github.com/state-spaces/mamba.git@main')
 
 

--- a/python_scripts/Falcon_H1-Alpaca.py
+++ b/python_scripts/Falcon_H1-Alpaca.py
@@ -39,7 +39,27 @@ get_ipython().system('pip install "unsloth[colab-new] @ git+https://github.com/u
 # In[ ]:
 
 
-get_ipython().system('pip install --force-reinstall git+https://github.com/huggingface/transformers.git')
+get_ipython().system('pip install --no-deps git+https://github.com/huggingface/transformers.git # Need main branch for Falcon H1 models')
+# --no-deps above is deliberate. Without it pip re-resolves the entire tree
+# rather than only what is missing: measured, `--force-reinstall` on this URL
+# lands numpy 2.5.2 on top of the numpy 2.0.2 Colab boots with. Colab has
+# already imported numpy before cell 1 runs, and numpy is a C extension that
+# cannot be swapped under a live kernel, so the next Unsloth import stops with
+# "numpy was upgraded mid-session ... Please restart your runtime/kernel" and
+# no later cell can repair it. Same failure the QAT install cell pins numpy
+# against.
+# The cost of --no-deps is that pip enforces nothing transformers main
+# declares. It only warns, and still exits 0, so every requirement it lists is
+# a delayed import error waiting to happen. The rule, rather than adding one
+# more floor each time one surfaces: take install_requires from transformers
+# main setup.py and raise every entry the base images fall short of. Both
+# images reach this cell on huggingface_hub 0.36.2 and Kaggle ships
+# safetensors 0.7.0, so those two need raising; tokenizers 0.22.2 already sits
+# inside its window and is pinned only to hold it under the 0.23.0 cap that
+# nothing else here enforces.
+# tests/test_transformers_main_no_deps_floors.py holds this line to that rule,
+# and tests/test_transformers_main_installs_use_no_deps.py holds the flag.
+get_ipython().system('pip install "huggingface_hub>=1.5.0,<2.0" "safetensors>=0.8.0" "tokenizers>=0.22.0,<=0.23.0"')
 
 
 # In[ ]:

--- a/tests/test_force_reinstall_does_not_replace_numpy.py
+++ b/tests/test_force_reinstall_does_not_replace_numpy.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Installing transformers main without `--no-deps` re-resolves numpy.
+"""Force-reinstalling transformers main drags numpy in behind it.
 
 `Falcon_H1-Alpaca.ipynb` installed transformers main as
 
@@ -30,7 +30,7 @@ and died two cells later on a free Colab T4:
 
 `--force-reinstall` tells pip to ignore what is installed and resolve the whole
 dependency tree from scratch, so numpy comes back at the newest release even
-though the numpy already present satisfied every requirement. Measured with
+though the numpy already there satisfied every requirement. Measured with
 `pip install --dry-run --report` against a Colab-shaped environment
 (numpy 2.0.2, transformers 4.56.2):
 
@@ -40,16 +40,25 @@ though the numpy already present satisfied every requirement. Measured with
 Colab has imported numpy before cell 1 executes, and numpy is a C extension
 that cannot be swapped under a live kernel, so no later cell can undo it. The
 only fix available to a notebook is not to change numpy on disk at all. That is
-the same reasoning `tests/test_qat_numpy_pin.py` already applies to the QAT
-install cell, which pins numpy beside `fbgemm-gpu-genai` for this exact error.
+the same reasoning `tests/test_qat_numpy_pin.py` applies to the QAT install
+cell, which pins numpy beside `fbgemm-gpu-genai` against this exact error.
 
 `tests/test_transformers_main_no_deps_floors.py` covers what a `--no-deps`
-install then owes: it matches on `--no-deps` and so cannot see a cell that
-never passed the flag. This file is the other half, the flag itself.
+install then owes. It matches on `--no-deps`, so a cell that never passed the
+flag is invisible to it; this file is the other half.
 
-Every other transformers-main install in the repo already uses `--no-deps`, for
-the related reason recorded there: without it pip also replaces the CUDA torch
-build the runtime already has.
+Scope is deliberately the pairing that was measured, `--force-reinstall`
+without `--no-deps`, and not every install that could in principle move numpy:
+
+  * a plain `pip install git+.../transformers` leaves an already-satisfied
+    numpy alone, so `GPT_OSS_*-Inference` and the `Ministral_3` Sudoku
+    notebooks, which install transformers from git that way, are not the shape
+    that broke and nothing is claimed about them here;
+  * the AMD cells that force-reinstall torch from a ROCm `--index-url` are a
+    different platform and a different resolve, unmeasured here, and belong
+    with whoever owns those images.
+
+Widening to either of those wants a measurement first, not a wider regex.
 """
 
 import json
@@ -62,11 +71,12 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 NOTEBOOK_DIRS = ("nb", "kaggle", "original_template")
 SCRIPT_DIRS = ("python_scripts", "molab")
 
-_TRANSFORMERS_MAIN = re.compile(
+_TRANSFORMERS_FROM_GIT = re.compile(
     r"git\+(?:https://|ssh://git@)github\.com/huggingface/transformers"
     r"(?:\.git)?(?![\w./-])")
 
-# `-U` is pip's spelling of `--upgrade` and does not imply `--no-deps`.
+# `-U` is pip's spelling of `--upgrade` and does not imply either of these.
+_FORCE_REINSTALL = re.compile(r"(?<![\w-])--force-reinstall(?![\w-])")
 _NO_DEPS = re.compile(r"(?<![\w-])--no-deps(?![\w-])")
 
 
@@ -74,7 +84,7 @@ def _logical_lines(text):
     """Source lines with backslash continuations joined, comments dropped.
 
     An install command wrapped over several lines is one command to the shell,
-    so `--no-deps` on any of its physical lines counts.
+    so a flag on any of its physical lines counts.
     """
     joined = []
     buffer = ""
@@ -93,12 +103,14 @@ def _logical_lines(text):
 
 
 def _offending_lines(text):
-    """Install lines that fetch transformers main without `--no-deps`."""
+    """Install lines that force-reinstall transformers with its dependencies."""
     bad = []
     for line in _logical_lines(text):
-        if not _TRANSFORMERS_MAIN.search(line):
-            continue
         if "install" not in line:
+            continue
+        if not _TRANSFORMERS_FROM_GIT.search(line):
+            continue
+        if not _FORCE_REINSTALL.search(line):
             continue
         if _NO_DEPS.search(line):
             continue
@@ -133,19 +145,20 @@ def test_there_are_files_to_check():
     assert len(_CASES) > 100
 
 
-def test_some_file_still_installs_transformers_main():
+def test_some_file_still_installs_transformers_from_git():
     """Or every check below passes by matching nothing at all."""
     hits = [name for name, path in _CASES
-            if any(_TRANSFORMERS_MAIN.search(source) for source in _sources(path))]
+            if any(_TRANSFORMERS_FROM_GIT.search(source)
+                   for source in _sources(path))]
     assert hits
 
 
 @pytest.mark.parametrize("name, path", _CASES, ids = [name for name, _ in _CASES])
-def test_transformers_main_is_installed_with_no_deps(name, path):
+def test_transformers_is_not_force_reinstalled_with_its_dependencies(name, path):
     for source in _sources(path):
         bad = _offending_lines(source)
         assert not bad, (
-            f"{name} installs transformers main without --no-deps:\n"
+            f"{name} force-reinstalls transformers without --no-deps:\n"
             f"    {bad[0]}\n"
             f"pip then re-resolves the whole dependency tree and replaces "
             f"numpy, which Colab and Kaggle have already imported before the "
@@ -176,14 +189,27 @@ def test_detector_accepts_the_liquid_lfm2_line():
     assert _offending_lines(line) == []
 
 
+def test_a_plain_install_is_out_of_scope():
+    """pip leaves an already-satisfied numpy alone without --force-reinstall."""
+    line = ("!uv pip install --system -qqq "
+            "git+https://github.com/huggingface/transformers")
+    assert _offending_lines(line) == []
+
+
+def test_a_pinned_commit_is_still_transformers_from_git():
+    line = ("!pip install --force-reinstall git+https://github.com/huggingface/"
+            "transformers.git@bf3f0ae70d0e902efab4b8517fce88f6697636ce")
+    assert _offending_lines(line)
+
+
 def test_no_deps_anywhere_in_a_continued_command_counts():
-    text = ("!uv pip install --system -qqq --no-deps accelerate peft \\\n"
+    text = ("!uv pip install --system -qqq --force-reinstall --no-deps \\\n"
             "    git+https://github.com/huggingface/transformers.git\n")
     assert _offending_lines(text) == []
 
 
 def test_a_continued_command_without_the_flag_is_still_flagged():
-    text = ("!uv pip install --system -qqq accelerate peft \\\n"
+    text = ("!uv pip install --system -qqq --force-reinstall accelerate \\\n"
             "    git+https://github.com/huggingface/transformers.git\n")
     assert _offending_lines(text)
 
@@ -200,11 +226,15 @@ def test_another_repository_under_huggingface_is_not_transformers():
     assert _offending_lines(line) == []
 
 
-def test_a_released_pin_is_not_a_main_install():
-    assert _offending_lines('!pip install --force-reinstall transformers==4.56.2') == []
+def test_a_released_pin_is_not_a_git_install():
+    assert _offending_lines(
+        "!pip install --force-reinstall transformers==4.56.2") == []
 
 
-def test_no_deps_must_be_the_whole_flag():
-    line = ("!pip install --no-deps-please "
-            "git+https://github.com/huggingface/transformers.git")
-    assert _offending_lines(line)
+def test_the_flags_must_be_whole_flags():
+    assert _offending_lines(
+        "!pip install --no-deps-please --force-reinstall "
+        "git+https://github.com/huggingface/transformers.git")
+    assert _offending_lines(
+        "!pip install --force-reinstall-all "
+        "git+https://github.com/huggingface/transformers.git") == []

--- a/tests/test_transformers_main_installs_use_no_deps.py
+++ b/tests/test_transformers_main_installs_use_no_deps.py
@@ -1,0 +1,210 @@
+# Unsloth Notebooks - Notebooks for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Installing transformers main without `--no-deps` re-resolves numpy.
+
+`Falcon_H1-Alpaca.ipynb` installed transformers main as
+
+    !pip install --force-reinstall git+https://github.com/huggingface/transformers.git
+
+and died two cells later on a free Colab T4:
+
+    ***** numpy was upgraded mid-session (loaded: 2.0.2, installed: 2.5.2) but
+    the kernel still has the old version in memory ... Please restart your
+    runtime/kernel *****
+
+`--force-reinstall` tells pip to ignore what is installed and resolve the whole
+dependency tree from scratch, so numpy comes back at the newest release even
+though the numpy already present satisfied every requirement. Measured with
+`pip install --dry-run --report` against a Colab-shaped environment
+(numpy 2.0.2, transformers 4.56.2):
+
+    --force-reinstall  ->  27 distributions, including numpy 2.5.2
+    --no-deps          ->  1 distribution, transformers alone
+
+Colab has imported numpy before cell 1 executes, and numpy is a C extension
+that cannot be swapped under a live kernel, so no later cell can undo it. The
+only fix available to a notebook is not to change numpy on disk at all. That is
+the same reasoning `tests/test_qat_numpy_pin.py` already applies to the QAT
+install cell, which pins numpy beside `fbgemm-gpu-genai` for this exact error.
+
+`tests/test_transformers_main_no_deps_floors.py` covers what a `--no-deps`
+install then owes: it matches on `--no-deps` and so cannot see a cell that
+never passed the flag. This file is the other half, the flag itself.
+
+Every other transformers-main install in the repo already uses `--no-deps`, for
+the related reason recorded there: without it pip also replaces the CUDA torch
+build the runtime already has.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+NOTEBOOK_DIRS = ("nb", "kaggle", "original_template")
+SCRIPT_DIRS = ("python_scripts", "molab")
+
+_TRANSFORMERS_MAIN = re.compile(
+    r"git\+(?:https://|ssh://git@)github\.com/huggingface/transformers"
+    r"(?:\.git)?(?![\w./-])")
+
+# `-U` is pip's spelling of `--upgrade` and does not imply `--no-deps`.
+_NO_DEPS = re.compile(r"(?<![\w-])--no-deps(?![\w-])")
+
+
+def _logical_lines(text):
+    """Source lines with backslash continuations joined, comments dropped.
+
+    An install command wrapped over several lines is one command to the shell,
+    so `--no-deps` on any of its physical lines counts.
+    """
+    joined = []
+    buffer = ""
+    for line in text.splitlines():
+        stripped = line.strip()
+        if buffer == "" and stripped.startswith("#"):
+            continue
+        if stripped.endswith("\\"):
+            buffer += stripped[:-1] + " "
+            continue
+        joined.append(buffer + stripped)
+        buffer = ""
+    if buffer:
+        joined.append(buffer)
+    return joined
+
+
+def _offending_lines(text):
+    """Install lines that fetch transformers main without `--no-deps`."""
+    bad = []
+    for line in _logical_lines(text):
+        if not _TRANSFORMERS_MAIN.search(line):
+            continue
+        if "install" not in line:
+            continue
+        if _NO_DEPS.search(line):
+            continue
+        bad.append(line)
+    return bad
+
+
+def _sources(path):
+    if path.suffix == ".ipynb":
+        notebook = json.loads(path.read_text(encoding = "utf-8"))
+        return ["".join(cell.get("source", []))
+                for cell in notebook.get("cells", [])
+                if cell.get("cell_type") == "code"]
+    return [path.read_text(encoding = "utf-8")]
+
+
+def _candidates():
+    for directory in NOTEBOOK_DIRS:
+        for path in sorted((REPO_ROOT / directory).glob("*.ipynb")):
+            yield path
+    for directory in SCRIPT_DIRS:
+        root = REPO_ROOT / directory
+        if root.is_dir():
+            for path in sorted(root.glob("*.py")):
+                yield path
+
+
+_CASES = [(str(path.relative_to(REPO_ROOT)), path) for path in _candidates()]
+
+
+def test_there_are_files_to_check():
+    assert len(_CASES) > 100
+
+
+def test_some_file_still_installs_transformers_main():
+    """Or every check below passes by matching nothing at all."""
+    hits = [name for name, path in _CASES
+            if any(_TRANSFORMERS_MAIN.search(source) for source in _sources(path))]
+    assert hits
+
+
+@pytest.mark.parametrize("name, path", _CASES, ids = [name for name, _ in _CASES])
+def test_transformers_main_is_installed_with_no_deps(name, path):
+    for source in _sources(path):
+        bad = _offending_lines(source)
+        assert not bad, (
+            f"{name} installs transformers main without --no-deps:\n"
+            f"    {bad[0]}\n"
+            f"pip then re-resolves the whole dependency tree and replaces "
+            f"numpy, which Colab and Kaggle have already imported before the "
+            f"first cell runs. The kernel keeps the old C extension, Unsloth "
+            f"refuses to continue with \"numpy was upgraded mid-session\", and "
+            f"no later cell can repair it. Add --no-deps and pin the floors "
+            f"the base images fall short of, the way every other "
+            f"transformers-main cell in this repo does")
+
+
+# --- detector self-tests -------------------------------------------------
+
+def test_detector_flags_the_line_that_broke_falcon_h1():
+    line = ("!pip install --force-reinstall "
+            "git+https://github.com/huggingface/transformers.git ")
+    assert _offending_lines(line) == [line.strip()]
+
+
+def test_detector_flags_the_uv_spelling_too():
+    line = ("!uv pip install --system -qqq --upgrade --force-reinstall "
+            "git+https://github.com/huggingface/transformers.git")
+    assert _offending_lines(line)
+
+
+def test_detector_accepts_the_liquid_lfm2_line():
+    line = ("!pip install --no-deps git+https://github.com/huggingface/"
+            "transformers.git # Need main branch for Liquid LFM2 models")
+    assert _offending_lines(line) == []
+
+
+def test_no_deps_anywhere_in_a_continued_command_counts():
+    text = ("!uv pip install --system -qqq --no-deps accelerate peft \\\n"
+            "    git+https://github.com/huggingface/transformers.git\n")
+    assert _offending_lines(text) == []
+
+
+def test_a_continued_command_without_the_flag_is_still_flagged():
+    text = ("!uv pip install --system -qqq accelerate peft \\\n"
+            "    git+https://github.com/huggingface/transformers.git\n")
+    assert _offending_lines(text)
+
+
+def test_a_commented_out_line_is_not_an_install():
+    text = ("# !pip install --force-reinstall "
+            "git+https://github.com/huggingface/transformers.git\n")
+    assert _offending_lines(text) == []
+
+
+def test_another_repository_under_huggingface_is_not_transformers():
+    line = ("!pip install --force-reinstall "
+            "git+https://github.com/huggingface/transformers-neuronx.git")
+    assert _offending_lines(line) == []
+
+
+def test_a_released_pin_is_not_a_main_install():
+    assert _offending_lines('!pip install --force-reinstall transformers==4.56.2') == []
+
+
+def test_no_deps_must_be_the_whole_flag():
+    line = ("!pip install --no-deps-please "
+            "git+https://github.com/huggingface/transformers.git")
+    assert _offending_lines(line)


### PR DESCRIPTION
### The bug

`Falcon_H1-Alpaca.ipynb` on a free Colab T4 stops at the first Unsloth cell:

```
RuntimeError: ***** numpy was upgraded mid-session (loaded: 2.0.2,
installed: 2.5.2) but the kernel still has the old version in memory. numpy
uses C extensions that cannot be reloaded without restarting. Please restart
your runtime/kernel after installing packages. *****
```

raised by unsloth_zoo's guard in `temporary_patches/utils.py`. Every cell after
it is cascade.

### Root cause

Colab boots with numpy 2.0.2 already imported, before cell 1 runs. Nothing in
the notebook imports it; the guard reports it as loaded anyway.

The notebook's third install cell was

```python
!pip install --force-reinstall git+https://github.com/huggingface/transformers.git
```

`--force-reinstall` tells pip to ignore what is installed and re-resolve the
whole dependency tree, so numpy is fetched at the newest release even though the
numpy already present satisfied every requirement. Measured with
`pip install --dry-run --report` in a venv shaped like the Colab runtime at that
point (numpy 2.0.2, transformers 4.56.2):

| flags | distributions pip would install |
| --- | --- |
| `--force-reinstall` | 27, including **numpy 2.5.2** |
| `--no-deps` | 1, transformers alone |

2.5.2 is exactly the version the traceback names. numpy is a C extension, so no
later cell can swap it under a live kernel; the only fix available to a notebook
is not to change it on disk at all.

### Relation to #337

#337 fixes a neighbouring failure, torch downgraded on disk under a kernel that
already loaded libtorch, with a generator helper
`_defer_torch_imports_past_downgrade` that rewrites an early `import torch` to
`importlib.metadata` and relocates torch-importing lines past the downgrade cell.

**This case does not generalise into that helper, and this PR does not touch
`update_all_notebooks.py`.** That helper works by moving a notebook-authored
import. Here there is no notebook-authored numpy import to move: the Colab
kernel loads numpy before the first cell, so there is no ordering the generator
could produce that would help. The two failures share a symptom and not a
remedy.

The mechanism that does apply is the one this repo already uses for exactly this
error message: `_pin_qat_numpy_beside_fbgemm`, guarded by
`tests/test_qat_numpy_pin.py`, which pins numpy beside `fbgemm-gpu-genai`
because that force-reinstall had the same effect.

### The fix

Adopt the idiom every other transformers-main install cell in the repo already
uses, `--no-deps` plus explicit floors:

```python
!pip install --no-deps git+https://github.com/huggingface/transformers.git
!pip install "huggingface_hub>=1.5.0,<2.0" "safetensors>=0.8.0" "tokenizers>=0.22.0,<=0.23.0"
```

That is `Liquid_LFM2-Conversational`'s cell, in the same hybrid-Mamba family.
`--force-reinstall` is dropped rather than kept beside `--no-deps`: pip installs
a direct git URL regardless of what is on disk, so it was buying nothing and
paying for it with the whole dependency tree.

The floors are not optional once `--no-deps` is set. `tests/test_transformers_main_no_deps_floors.py`
matches on `--no-deps`, so this notebook was invisible to it while it used
`--force-reinstall`; with the flag added the notebook comes under that gate too,
and the three pins are what it requires.

### Source of truth

`Falcon_H1-Alpaca.ipynb` is in `DONT_UPDATE_EXCEPTIONS` and has no
`original_template/` file, so `nb/` is its source and the edit is by hand there.
`original_template/Falcon_H1_(0.5B)-Alpaca.ipynb` is a different notebook, which
generates `nb/Falcon_H1_(0.5B)-Alpaca.ipynb`, and is not affected.

`nb/AMD-Falcon_H1-Alpaca.ipynb` is minted from `nb/` via
`AMD_ONLY_NB_SOURCE_ALLOWLIST` and carried the same line with `uv` spelling. It
is regenerated rather than hand-edited: `update_all_notebooks.py --amd` moves
transformers into the existing `--no-deps` group and raises the hub and
safetensors floors on its own.

The generator's own churn on pristine main was measured first: `--amd` rewrites
80 files (41 AMD notebooks and 39 scripts) with a pre-existing spelling drift
unrelated to this change. This change adds exactly three files on top of that
baseline, and only those three are committed. `scripts/molab_generate.py`
likewise touches only `molab/Falcon_H1-Alpaca.py`.

### Exactly one notebook was affected

All of `nb/`, `kaggle/`, `original_template/`, `python_scripts/` and `molab/`
scanned for an install line that fetches transformers from git with
`--force-reinstall` and no `--no-deps`: `Falcon_H1-Alpaca` and its generated AMD
variant, and nothing else.

`GPT_OSS_BNB_(20B)-Inference`, `GPT_OSS_MXFP4_(20B)-Inference` and
`Ministral_3_(3B)_Reinforcement_Learning_Sudoku_Game` install transformers from
git *without* `--force-reinstall`, which leaves an already-satisfied numpy alone.
That is a different resolve and I have not measured it, so they are deliberately
left alone and the test says so.

### Regression test

`tests/test_force_reinstall_does_not_replace_numpy.py` fails on 4 files before
this change, `nb/Falcon_H1-Alpaca.ipynb`, `nb/AMD-Falcon_H1-Alpaca.ipynb` and
both scripts, and passes after. Its detector has cases both ways, including the
`uv` spelling, backslash-continued commands, commented-out lines,
`transformers-neuronx` and a released `transformers==` pin, so a regex that
stopped matching cannot leave the gate quietly green.

### Test results

```
python -m pytest tests/ -q --ignore=tests/security
10649 passed, 165 skipped in 393.26s
```

Main measured the same way on this machine: 9517 passed, 165 skipped, 0 failed.

### Not verified

No Colab was involved, so the fix's effect is by construction. What is measured
is the resolver behaviour, on this machine, with the versions the runtime holds
at that cell. What is not observed:

- that `Falcon_H1-Alpaca` now reaches training on a Colab T4;
- that transformers main still imports cleanly with only these three floors
  raised and every other dependency left at the Colab version. The floor table
  comes from `tests/test_transformers_main_no_deps_floors.py`, which is measured
  against transformers 5.15.0.dev0, and the same three pins are what
  `Liquid_LFM2-Conversational` runs with, but I have not imported transformers
  main under exactly this notebook's environment;
- anything about the AMD variant on ROCm hardware. It is regenerated, not
  reasoned about separately.
