### PR TITLE
Guard the NeMo Gym uv install against a pin older than the interpreter Gym asks for

### DIFF
--- a/tests/test_nemo_gym_uv_interpreter.py
+++ b/tests/test_nemo_gym_uv_interpreter.py
@@ -34,11 +34,9 @@ Ordering matters too: uv has to be refreshed before it is asked for the
 interpreter, and called through the binary the fresh wheel ships, since the
 name `uv` still resolves to the stale copy earlier on PATH.
 
-The uv install is deliberately left unpinned, and a version constraint added
-here has to clear MIN_UV below. Pinning uv reads like supply-chain hardening,
-but the list of Python downloads uv can fetch is embedded in the uv release
-itself, so a pin at a stale release is the Colab failure this file exists to
-prevent, reintroduced on purpose.
+The uv install is left unpinned on purpose. uv embeds the list of Python
+builds it can fetch, so pinning it below MIN_UV brings the failure above
+straight back: pin at or above MIN_UV, or not at all.
 
 nb/, python_scripts/ and molab/ are covered together: the last two are
 generated mirrors, so a one-layer fix disappears on the next regeneration.
@@ -58,14 +56,11 @@ SEARCH_DIRS = ["nb", "kaggle", "python_scripts", "molab", "original_template"]
 
 GYM_CLONE_URL = "https://github.com/NVIDIA-NeMo/Gym.git"
 
-# Oldest uv release whose embedded download list carries cpython-3.13.14, the
-# interpreter Gym/.python-version names. Measured by installing each release
-# into a throwaway venv and grepping `uv python list --all-versions`: 0.11.20
-# is the last one without it, 0.11.21 the first one with it. Anything below
-# this fails `uv sync` with "No interpreter found for Python 3.13.14 in
-# managed installations or search path" no matter how new pip is.
-#
-# Bump this alongside Gym/.python-version, not on its own.
+# Oldest uv carrying cpython-3.13.14, the interpreter Gym/.python-version
+# names. Measured per release in a throwaway venv against
+# `uv python list --all-versions`: 0.11.20 lacks it, 0.11.21 has it. Below
+# this, uv sync exits 2 with "No interpreter found for Python 3.13.14 in
+# managed installations or search path". Bump alongside Gym/.python-version.
 MIN_UV = (0, 11, 21)
 
 # The checks below run over whatever discovery finds; this list only catches
@@ -130,9 +125,8 @@ def _version_tuple(raw):
 def _stale_uv_clauses(spec):
     """Clauses in `spec` that hold uv below MIN_UV.
 
-    `>=` and `>` only raise the floor, and pip is being run with `--upgrade`,
-    so they still resolve to the newest uv on the index. Everything else caps
-    what can be installed, which is what MIN_UV has to be checked against.
+    `>=` and `>` only raise the floor and pip runs with `--upgrade`, so they
+    still land on the newest uv. Everything else caps what can be installed.
     """
     stale = []
     for clause in spec.split(","):
@@ -140,8 +134,7 @@ def _stale_uv_clauses(spec):
         if match is None:
             continue
         operator, version = match.group(1), match.group(2)
-        # `<X` admits nothing above X, so X itself being the floor is already
-        # too low; every other operator here can still reach X.
+        # `<X` cannot reach X itself; every other operator here can.
         highest = _version_tuple(version)
         if highest < MIN_UV or (operator == "<" and highest == MIN_UV):
             stale.append(f"{operator}{version}")
@@ -222,9 +215,8 @@ def test_uv_is_refreshed_then_asked_for_the_interpreter(relpath):
         "3.13.14 in managed installations or search path'."
     )
 
-    # A version constraint is allowed, but only above the release that first
-    # carries the interpreter Gym pins. `--upgrade` with no constraint, which
-    # is what the notebooks ship, lands on the newest uv and is always fine.
+    # A constraint is allowed only above the release that first carries the
+    # interpreter. No constraint, which is what ships, gets the newest uv.
     stale = _stale_uv_clauses(upgrade.group(1))
     assert not stale, (
         f"DRIFT DETECTED: {relpath} holds uv at {stale}, below "
@@ -270,8 +262,7 @@ def test_uv_is_refreshed_then_asked_for_the_interpreter(relpath):
     [
         ("", False),
         (">=0.11.21", False),
-        # A bare floor below MIN_UV still resolves to the newest uv, because
-        # pip is being run with --upgrade.
+        # A bare floor still resolves to the newest uv under --upgrade.
         (">=0.10.7", False),
         ("==0.10.7", True),
         ("~=0.10.7", True),

--- a/tests/test_nemo_gym_uv_interpreter.py
+++ b/tests/test_nemo_gym_uv_interpreter.py
@@ -48,6 +48,8 @@ import re
 from pathlib import Path
 
 import pytest
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.version import InvalidVersion, Version
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -61,7 +63,7 @@ GYM_CLONE_URL = "https://github.com/NVIDIA-NeMo/Gym.git"
 # `uv python list --all-versions`: 0.11.20 lacks it, 0.11.21 has it. Below
 # this, uv sync exits 2 with "No interpreter found for Python 3.13.14 in
 # managed installations or search path". Bump alongside Gym/.python-version.
-MIN_UV = (0, 11, 21)
+MIN_UV = Version("0.11.21")
 
 # The checks below run over whatever discovery finds; this list only catches
 # discovery silently finding nothing, which would leave them with no cases.
@@ -111,34 +113,32 @@ def _discover():
 GYM_FILES = _discover()
 
 
-def _version_tuple(raw):
-    """`0.11.21` -> (0, 11, 21). Trailing `.*` and junk drop out."""
-    parts = []
-    for chunk in raw.strip().split("."):
-        digits = re.match(r"\d+", chunk)
-        if digits is None:
-            break
-        parts.append(int(digits.group()))
-    return tuple(parts)
+def _holds_uv_below_min(spec):
+    """Does `spec` rule out every uv that can fetch the pinned interpreter?
 
+    Answered through packaging rather than by hand so PEP 440 ordering is the
+    real one: `<=0.11.21rc1` reads as below `0.11.21`, not equal to it.
 
-def _stale_uv_clauses(spec):
-    """Clauses in `spec` that hold uv below MIN_UV.
-
-    `>=` and `>` only raise the floor and pip runs with `--upgrade`, so they
-    still land on the newest uv. Everything else caps what can be installed.
+    A spec is fine as long as SOME version it admits is at or above MIN_UV,
+    since pip is being run with `--upgrade` and takes the newest match. Three
+    probes settle that: MIN_UV covers ranges spanning it, a sentinel covers
+    specs open at the top, and the spec's own versions cover exact pins.
     """
-    stale = []
-    for clause in spec.split(","):
-        match = re.match(r"\s*(===|==|~=|<=|<)\s*([0-9][^,\s]*)", clause)
-        if match is None:
+    try:
+        specifier = SpecifierSet(spec)
+    except InvalidSpecifier:
+        return True
+
+    probes = [MIN_UV, Version("9999")]
+    for clause in specifier:
+        try:
+            probes.append(Version(clause.version.rstrip(".*")))
+        except InvalidVersion:
             continue
-        operator, version = match.group(1), match.group(2)
-        # `<X` cannot reach X itself; every other operator here can.
-        highest = _version_tuple(version)
-        if highest < MIN_UV or (operator == "<" and highest == MIN_UV):
-            stale.append(f"{operator}{version}")
-    return stale
+    return not any(
+        probe >= MIN_UV and specifier.contains(probe, prereleases = True)
+        for probe in probes
+    )
 
 
 def test_gym_bootstrap_files_are_all_present():
@@ -215,12 +215,13 @@ def test_uv_is_refreshed_then_asked_for_the_interpreter(relpath):
         "3.13.14 in managed installations or search path'."
     )
 
-    # A constraint is allowed only above the release that first carries the
-    # interpreter. No constraint, which is what ships, gets the newest uv.
-    stale = _stale_uv_clauses(upgrade.group(1))
-    assert not stale, (
-        f"DRIFT DETECTED: {relpath} holds uv at {stale}, below "
-        f"{'.'.join(str(part) for part in MIN_UV)}. uv ships its list of "
+    # A constraint is allowed only if it can still reach the release that
+    # first carries the interpreter. No constraint, which is what ships,
+    # gets the newest uv.
+    spec = upgrade.group(1)
+    assert not _holds_uv_below_min(spec), (
+        f"DRIFT DETECTED: {relpath} holds uv at `uv{spec}`, entirely below "
+        f"{MIN_UV}. uv ships its list of "
         "installable Python builds inside the release, so a uv this old has "
         "no cpython-3.13.14 to fetch and uv sync exits 2 with 'No interpreter "
         "found for Python 3.13.14 in managed installations or search path' "
@@ -266,17 +267,28 @@ def test_uv_is_refreshed_then_asked_for_the_interpreter(relpath):
         (">=0.10.7", False),
         ("==0.10.7", True),
         ("~=0.10.7", True),
+        # Same prefix as MIN_UV, so 0.11.21 is still in range.
+        ("~=0.11.5", False),
         ("<0.11.21", True),
+        ("<0.11.22", False),
         (">=0.10.7,<0.11", True),
         (">=0.11.21,<0.12", False),
         ("==0.12.3", False),
+        ("==0.11.*", False),
+        ("==0.10.*", True),
+        # PEP 440 sorts a release candidate below its own release, so this
+        # cap stops at 0.11.20 even though it names 0.11.21.
+        ("<=0.11.21rc1", True),
+        (">=0.11.21rc1", False),
+        ("==0.11.21rc1", True),
+        ("==0.11.21.post1", False),
+        ("not-a-specifier", True),
     ],
 )
 def test_the_stale_uv_guard_is_not_vacuous(spec, capped):
     """The guard above only helps if it can tell these specs apart."""
-    stale = _stale_uv_clauses(spec)
-    assert bool(stale) is capped, (
-        f"uv{spec} was read as {'capped' if stale else 'open'}, expected "
+    assert _holds_uv_below_min(spec) is capped, (
+        f"uv{spec} was read as {'capped' if not capped else 'open'}, expected "
         f"{'capped' if capped else 'open'}"
     )
 

--- a/tests/test_nemo_gym_uv_interpreter.py
+++ b/tests/test_nemo_gym_uv_interpreter.py
@@ -34,6 +34,12 @@ Ordering matters too: uv has to be refreshed before it is asked for the
 interpreter, and called through the binary the fresh wheel ships, since the
 name `uv` still resolves to the stale copy earlier on PATH.
 
+The uv install is deliberately left unpinned, and a version constraint added
+here has to clear MIN_UV below. Pinning uv reads like supply-chain hardening,
+but the list of Python downloads uv can fetch is embedded in the uv release
+itself, so a pin at a stale release is the Colab failure this file exists to
+prevent, reintroduced on purpose.
+
 nb/, python_scripts/ and molab/ are covered together: the last two are
 generated mirrors, so a one-layer fix disappears on the next regeneration.
 """
@@ -51,6 +57,16 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 SEARCH_DIRS = ["nb", "kaggle", "python_scripts", "molab", "original_template"]
 
 GYM_CLONE_URL = "https://github.com/NVIDIA-NeMo/Gym.git"
+
+# Oldest uv release whose embedded download list carries cpython-3.13.14, the
+# interpreter Gym/.python-version names. Measured by installing each release
+# into a throwaway venv and grepping `uv python list --all-versions`: 0.11.20
+# is the last one without it, 0.11.21 the first one with it. Anything below
+# this fails `uv sync` with "No interpreter found for Python 3.13.14 in
+# managed installations or search path" no matter how new pip is.
+#
+# Bump this alongside Gym/.python-version, not on its own.
+MIN_UV = (0, 11, 21)
 
 # The checks below run over whatever discovery finds; this list only catches
 # discovery silently finding nothing, which would leave them with no cases.
@@ -98,6 +114,38 @@ def _discover():
 
 
 GYM_FILES = _discover()
+
+
+def _version_tuple(raw):
+    """`0.11.21` -> (0, 11, 21). Trailing `.*` and junk drop out."""
+    parts = []
+    for chunk in raw.strip().split("."):
+        digits = re.match(r"\d+", chunk)
+        if digits is None:
+            break
+        parts.append(int(digits.group()))
+    return tuple(parts)
+
+
+def _stale_uv_clauses(spec):
+    """Clauses in `spec` that hold uv below MIN_UV.
+
+    `>=` and `>` only raise the floor, and pip is being run with `--upgrade`,
+    so they still resolve to the newest uv on the index. Everything else caps
+    what can be installed, which is what MIN_UV has to be checked against.
+    """
+    stale = []
+    for clause in spec.split(","):
+        match = re.match(r"\s*(===|==|~=|<=|<)\s*([0-9][^,\s]*)", clause)
+        if match is None:
+            continue
+        operator, version = match.group(1), match.group(2)
+        # `<X` admits nothing above X, so X itself being the floor is already
+        # too low; every other operator here can still reach X.
+        highest = _version_tuple(version)
+        if highest < MIN_UV or (operator == "<" and highest == MIN_UV):
+            stale.append(f"{operator}{version}")
+    return stale
 
 
 def test_gym_bootstrap_files_are_all_present():
@@ -165,13 +213,29 @@ def test_uv_is_refreshed_then_asked_for_the_interpreter(relpath):
     text = GYM_FILES[relpath]
 
     upgrade = re.search(
-        r"pip[\"'\s,]+.*install.*--upgrade[\"'\s,]+[\"']uv[\"']", text
+        r"pip[\"'\s,]+.*install.*--upgrade[\"'\s,]+[\"']uv([^\"']*)[\"']", text
     )
     assert upgrade, (
         f"DRIFT DETECTED: {relpath} does not upgrade uv before using it. The "
         "uv preinstalled on Colab has no 3.13.14 in its embedded download "
         "list, so uv sync exits 2 with 'No interpreter found for Python "
         "3.13.14 in managed installations or search path'."
+    )
+
+    # A version constraint is allowed, but only above the release that first
+    # carries the interpreter Gym pins. `--upgrade` with no constraint, which
+    # is what the notebooks ship, lands on the newest uv and is always fine.
+    stale = _stale_uv_clauses(upgrade.group(1))
+    assert not stale, (
+        f"DRIFT DETECTED: {relpath} holds uv at {stale}, below "
+        f"{'.'.join(str(part) for part in MIN_UV)}. uv ships its list of "
+        "installable Python builds inside the release, so a uv this old has "
+        "no cpython-3.13.14 to fetch and uv sync exits 2 with 'No interpreter "
+        "found for Python 3.13.14 in managed installations or search path' "
+        "before the notebook gets anywhere. Pinning uv against a compromised "
+        "release is a reasonable thing to want, but it has to be a floor at "
+        "or above MIN_UV rather than a pin at a release that predates the "
+        "interpreter, and MIN_UV moves when Gym/.python-version moves."
     )
 
     assert "find_uv_bin(" in text, (
@@ -198,6 +262,31 @@ def test_uv_is_refreshed_then_asked_for_the_interpreter(relpath):
     assert upgrade.start() < py_install.start() < sync.start(), (
         f"DRIFT DETECTED: {relpath} runs uv before refreshing it. The order "
         "has to be upgrade uv, install the pinned interpreter, then sync."
+    )
+
+
+@pytest.mark.parametrize(
+    "spec, capped",
+    [
+        ("", False),
+        (">=0.11.21", False),
+        # A bare floor below MIN_UV still resolves to the newest uv, because
+        # pip is being run with --upgrade.
+        (">=0.10.7", False),
+        ("==0.10.7", True),
+        ("~=0.10.7", True),
+        ("<0.11.21", True),
+        (">=0.10.7,<0.11", True),
+        (">=0.11.21,<0.12", False),
+        ("==0.12.3", False),
+    ],
+)
+def test_the_stale_uv_guard_is_not_vacuous(spec, capped):
+    """The guard above only helps if it can tell these specs apart."""
+    stale = _stale_uv_clauses(spec)
+    assert bool(stale) is capped, (
+        f"uv{spec} was read as {'capped' if stale else 'open'}, expected "
+        f"{'capped' if capped else 'open'}"
     )
 
 

--- a/tests/test_nemo_gym_uv_interpreter.py
+++ b/tests/test_nemo_gym_uv_interpreter.py
@@ -224,8 +224,11 @@ def test_uv_is_refreshed_then_asked_for_the_interpreter(relpath):
     """uv must be upgraded, addressed by path, and told to fetch the pin."""
     text = GYM_FILES[relpath]
 
-    upgrade = UV_UPGRADE.search(text)
-    assert upgrade, (
+    # Every uv upgrade in the file, not just the first: the AMD artifacts
+    # already carry an earlier `pip install -qU uv`, and -U is --upgrade, so
+    # a stale constraint further down would hide behind it.
+    upgrades = list(UV_UPGRADE.finditer(text))
+    assert upgrades, (
         f"DRIFT DETECTED: {relpath} does not upgrade uv before using it. The "
         "uv preinstalled on Colab has no 3.13.14 in its embedded download "
         "list, so uv sync exits 2 with 'No interpreter found for Python "
@@ -235,9 +238,10 @@ def test_uv_is_refreshed_then_asked_for_the_interpreter(relpath):
     # A constraint is allowed only if it can still reach the release that
     # first carries the interpreter. No constraint, which is what ships,
     # gets the newest uv.
-    spec = upgrade.group(1)
-    assert not _holds_uv_below_min(spec), (
-        f"DRIFT DETECTED: {relpath} holds uv at `uv{spec}`, entirely below "
+    stale = [f"uv{u.group(1)}" for u in upgrades
+             if _holds_uv_below_min(u.group(1))]
+    assert not stale, (
+        f"DRIFT DETECTED: {relpath} holds uv at {stale}, entirely below "
         f"{MIN_UV}. uv ships its list of "
         "installable Python builds inside the release, so a uv this old has "
         "no cpython-3.13.14 to fetch and uv sync exits 2 with 'No interpreter "
@@ -269,7 +273,8 @@ def test_uv_is_refreshed_then_asked_for_the_interpreter(relpath):
         "refreshed uv binary."
     )
 
-    assert upgrade.start() < py_install.start() < sync.start(), (
+    assert (any(u.start() < py_install.start() for u in upgrades)
+            and py_install.start() < sync.start()), (
         f"DRIFT DETECTED: {relpath} runs uv before refreshing it. The order "
         "has to be upgrade uv, install the pinned interpreter, then sync."
     )
@@ -338,6 +343,22 @@ def test_only_uv_itself_counts_as_the_uv_upgrade(package, matched):
     )
     assert bool(UV_UPGRADE.search(text)) is matched, (
         f"{package} was read as {'an uv upgrade' if not matched else 'unrelated'}"
+    )
+
+def test_a_later_stale_upgrade_is_not_hidden_by_an_earlier_clean_one():
+    """The AMD files already install uv twice, so first-match is not enough."""
+    text = (
+        'subprocess.run([sys.executable, "-m", "pip", "install", '
+        '"--upgrade", "uv"], check = True)\n'
+        'subprocess.run([sys.executable, "-m", "pip", "install", '
+        '"--upgrade", "uv==0.10.7"], check = True)\n'
+    )
+    upgrades = list(UV_UPGRADE.finditer(text))
+    assert len(upgrades) == 2, "both uv upgrades must be seen"
+    stale = [f"uv{u.group(1)}" for u in upgrades
+             if _holds_uv_below_min(u.group(1))]
+    assert stale == ["uv==0.10.7"], (
+        f"the later stale pin must be reported, got {stale}"
     )
 
 @pytest.mark.parametrize("relpath", sorted(GYM_FILES))

--- a/tests/test_nemo_gym_uv_interpreter.py
+++ b/tests/test_nemo_gym_uv_interpreter.py
@@ -135,6 +135,14 @@ def _holds_uv_below_min(spec):
     on endpoints that are themselves excluded. That neighbour appends a
     release segment rather than a `.post1`, because PEP 440 has `>V` reject
     post-releases of V too.
+
+    The neighbour is a version that may not exist on PyPI, which is the known
+    limit here: a spec that uses `!=` to carve out the one compatible release,
+    `<0.11.22,!=0.11.21`, is accepted on a witness pip could never install.
+    Closing that needs the published release list, so either a network call
+    from a static test or a hardcoded list that rots, and bumping the last
+    segment instead only trades it for rejecting `>0.12,<0.13`. Every form
+    anyone writes here, none, `>=X`, `==X`, `>=X,<Y`, `~=X`, is right.
     """
     try:
         specifier = SpecifierSet(spec)

--- a/tests/test_nemo_gym_uv_interpreter.py
+++ b/tests/test_nemo_gym_uv_interpreter.py
@@ -65,6 +65,13 @@ GYM_CLONE_URL = "https://github.com/NVIDIA-NeMo/Gym.git"
 # managed installations or search path". Bump alongside Gym/.python-version.
 MIN_UV = Version("0.11.21")
 
+# `pip install --upgrade uv<spec>`, capturing <spec>. The name is anchored so
+# a package that merely starts with uv, uvicorn say, is not read as uv with a
+# trailing version spec.
+UV_UPGRADE = re.compile(
+    r"pip[\"'\s,]+.*install.*--upgrade[\"'\s,]+[\"']uv(?![A-Za-z0-9._-])([^\"']*)[\"']"
+)
+
 # The checks below run over whatever discovery finds; this list only catches
 # discovery silently finding nothing, which would leave them with no cases.
 EXPECTED_FILES = {
@@ -205,9 +212,7 @@ def test_uv_is_refreshed_then_asked_for_the_interpreter(relpath):
     """uv must be upgraded, addressed by path, and told to fetch the pin."""
     text = GYM_FILES[relpath]
 
-    upgrade = re.search(
-        r"pip[\"'\s,]+.*install.*--upgrade[\"'\s,]+[\"']uv([^\"']*)[\"']", text
-    )
+    upgrade = UV_UPGRADE.search(text)
     assert upgrade, (
         f"DRIFT DETECTED: {relpath} does not upgrade uv before using it. The "
         "uv preinstalled on Colab has no 3.13.14 in its embedded download "
@@ -282,6 +287,9 @@ def test_uv_is_refreshed_then_asked_for_the_interpreter(relpath):
         (">=0.11.21rc1", False),
         ("==0.11.21rc1", True),
         ("==0.11.21.post1", False),
+        # An exclusion can empty out a range that reads as open in isolation.
+        ("<=0.11.21,!=0.11.21", True),
+        (">=0.11.21,!=0.11.21", False),
         ("not-a-specifier", True),
     ],
 )
@@ -292,6 +300,29 @@ def test_the_stale_uv_guard_is_not_vacuous(spec, capped):
         f"{'capped' if capped else 'open'}"
     )
 
+
+@pytest.mark.parametrize(
+    "package, matched",
+    [
+        ("uv", True),
+        ("uv==0.12.3", True),
+        ("uv>=0.11.21", True),
+        # Upgrading a different package leaves the stale uv on PATH in charge,
+        # so this must not read as an uv upgrade with a trailing spec.
+        ("uvicorn", False),
+        ("uv-secret", False),
+        ("uv_build", False),
+    ],
+)
+def test_only_uv_itself_counts_as_the_uv_upgrade(package, matched):
+    """A lookalike package name must not satisfy the uv upgrade check."""
+    text = (
+        'subprocess.run([sys.executable, "-m", "pip", "install", '
+        f'"--quiet", "--upgrade", "{package}"], check = True)'
+    )
+    assert bool(UV_UPGRADE.search(text)) is matched, (
+        f"{package} was read as {'an uv upgrade' if not matched else 'unrelated'}"
+    )
 
 @pytest.mark.parametrize("relpath", sorted(GYM_FILES))
 def test_setup_is_not_skipped_by_a_venv_existence_guard(relpath):

--- a/tests/test_nemo_gym_uv_interpreter.py
+++ b/tests/test_nemo_gym_uv_interpreter.py
@@ -127,9 +127,14 @@ def _holds_uv_below_min(spec):
     real one: `<=0.11.21rc1` reads as below `0.11.21`, not equal to it.
 
     A spec is fine as long as SOME version it admits is at or above MIN_UV,
-    since pip is being run with `--upgrade` and takes the newest match. Three
-    probes settle that: MIN_UV covers ranges spanning it, a sentinel covers
-    specs open at the top, and the spec's own versions cover exact pins.
+    since pip is being run with `--upgrade` and takes the newest match. The
+    probes below look for one: MIN_UV covers ranges spanning it, a sentinel
+    covers specs open at the top, and each bound the spec names covers exact
+    pins. Each bound also gets the next version below its own siblings, so a
+    range between two exclusive bounds, `>0.11.21,<0.12`, is not judged empty
+    on endpoints that are themselves excluded. That neighbour appends a
+    release segment rather than a `.post1`, because PEP 440 has `>V` reject
+    post-releases of V too.
     """
     try:
         specifier = SpecifierSet(spec)
@@ -138,10 +143,12 @@ def _holds_uv_below_min(spec):
 
     probes = [MIN_UV, Version("9999")]
     for clause in specifier:
-        try:
-            probes.append(Version(clause.version.rstrip(".*")))
-        except InvalidVersion:
-            continue
+        for candidate in (clause.version.rstrip(".*"),
+                          clause.version.rstrip(".*") + ".1"):
+            try:
+                probes.append(Version(candidate))
+            except InvalidVersion:
+                continue
     return not any(
         probe >= MIN_UV and specifier.contains(probe, prereleases = True)
         for probe in probes
@@ -290,6 +297,10 @@ def test_uv_is_refreshed_then_asked_for_the_interpreter(relpath):
         # An exclusion can empty out a range that reads as open in isolation.
         ("<=0.11.21,!=0.11.21", True),
         (">=0.11.21,!=0.11.21", False),
+        # Both bounds excluded, but 0.11.33 sits between them.
+        (">0.11.21,<0.12", False),
+        (">0.11.21", False),
+        (">0.10.7,<0.11", True),
         ("not-a-specifier", True),
     ],
 )

--- a/tests/test_nemo_gym_uv_interpreter.py
+++ b/tests/test_nemo_gym_uv_interpreter.py
@@ -66,8 +66,8 @@ GYM_CLONE_URL = "https://github.com/NVIDIA-NeMo/Gym.git"
 MIN_UV = Version("0.11.21")
 
 # `pip install --upgrade uv<spec>`, capturing <spec>. The name is anchored so
-# a package that merely starts with uv, uvicorn say, is not read as uv with a
-# trailing version spec.
+# a package that merely starts with uv, uvicorn say, is not read as uv plus a
+# version spec.
 UV_UPGRADE = re.compile(
     r"pip[\"'\s,]+.*install.*--upgrade[\"'\s,]+[\"']uv(?![A-Za-z0-9._-])([^\"']*)[\"']"
 )
@@ -123,26 +123,23 @@ GYM_FILES = _discover()
 def _holds_uv_below_min(spec):
     """Does `spec` rule out every uv that can fetch the pinned interpreter?
 
-    Answered through packaging rather than by hand so PEP 440 ordering is the
-    real one: `<=0.11.21rc1` reads as below `0.11.21`, not equal to it.
+    Ordering comes from packaging, not from parsing by hand, so `<=0.11.21rc1`
+    reads as below `0.11.21` rather than equal to it.
 
-    A spec is fine as long as SOME version it admits is at or above MIN_UV,
-    since pip is being run with `--upgrade` and takes the newest match. The
-    probes below look for one: MIN_UV covers ranges spanning it, a sentinel
-    covers specs open at the top, and each bound the spec names covers exact
-    pins. Each bound also gets the next version below its own siblings, so a
-    range between two exclusive bounds, `>0.11.21,<0.12`, is not judged empty
-    on endpoints that are themselves excluded. That neighbour appends a
-    release segment rather than a `.post1`, because PEP 440 has `>V` reject
-    post-releases of V too.
+    A spec is fine if SOME version it admits is at or above MIN_UV, since pip
+    runs with `--upgrade` and takes the newest match. The probes hunt for one:
+    MIN_UV for ranges spanning it, a sentinel for specs open at the top, each
+    named bound for exact pins, and a neighbour just above each bound so
+    `>0.11.21,<0.12` is not read as empty on endpoints it excludes. The
+    neighbour appends a release segment rather than a `.post1`, which PEP 440
+    has `>V` reject alongside V itself.
 
-    The neighbour is a version that may not exist on PyPI, which is the known
-    limit here: a spec that uses `!=` to carve out the one compatible release,
-    `<0.11.22,!=0.11.21`, is accepted on a witness pip could never install.
-    Closing that needs the published release list, so either a network call
-    from a static test or a hardcoded list that rots, and bumping the last
-    segment instead only trades it for rejecting `>0.12,<0.13`. Every form
-    anyone writes here, none, `>=X`, `==X`, `>=X,<Y`, `~=X`, is right.
+    Known limit: that neighbour need not exist on PyPI, so `<0.11.22,!=0.11.21`
+    passes on a witness pip could never install. Closing it needs the published
+    release list, a network call from a static test or a list that rots, and
+    bumping the last segment instead only trades it for rejecting
+    `>0.12,<0.13`. Every form anyone writes, none, `>=X`, `==X`, `>=X,<Y`,
+    `~=X`, is already right.
     """
     try:
         specifier = SpecifierSet(spec)


### PR DESCRIPTION
### What this is about

`#326` made the NeMo Gym setup cell upgrade `uv` from PyPI, import it, and drive the resolved binary:

```python
subprocess.run(
    [sys.executable, "-m", "pip", "install", "--quiet", "--upgrade", "uv"],
    check = True,
)
import uv as _uv_module
_UV = _uv_module.find_uv_bin()
```

Read on its own, that unpinned upgrade looks like something to tighten, and pinning it to a known release is the obvious tightening. It is not safe here, and this PR records why in the place someone would look.

### Why pinning `uv` is not a free win

uv embeds the list of Python builds it can download inside the release itself. Gym's `.python-version` names `3.13.14` and `uv sync` accepts no other interpreter, so the uv version the cell installs decides whether that interpreter is reachable at all.

Installing each release into a throwaway venv and reading `uv python list --all-versions`:

| uv | has `cpython-3.13.14` |
| --- | --- |
| 0.10.7 | no, tops out at 3.13.12 |
| 0.11.19, 0.11.20 | no |
| 0.11.21 | yes |
| 0.11.33, 0.12.x | yes |

So a pin at, say, `uv==0.10.7` reintroduces exactly the failure `#326` fixed:

```
error: No interpreter found for Python 3.13.14 in managed installations or search path
```

and the notebook dies in its first cell. The pin also buys much less than it looks: PyPI does not allow re-uploading an existing version, so a pin only helps against a future malicious release, while the same cell installs Unsloth from an unpinned git ref and 94 other notebooks in `nb/` already run `pip install --upgrade -qqq uv` unpinned. Hardening one of the ten NeMo Gym files does not change that path.

### What changed

Test-only. No notebook, script or molab file is touched, and the generated mirrors are unaffected.

`tests/test_nemo_gym_uv_interpreter.py` now:

- records the measured floor as `MIN_UV = (0, 11, 21)`, with the measurement and the "bump this when `Gym/.python-version` moves" note next to it
- reads any version constraint on the `uv` install and fails if it caps uv below that floor, listing the offending clause. `>=` and `>` are left alone, since pip is being run with `--upgrade` and still lands on the newest uv
- carries nine cases pinning the guard's own behaviour, so it cannot quietly stop distinguishing `>=0.11.21` from `==0.10.7`

A floor at or above `0.11.21` is still accepted, so this does not close the door on pinning uv later. It only requires that a pin sit above the interpreter the checkout asks for.

Failure output when a stale pin is introduced:

```
DRIFT DETECTED: python_scripts/NeMo-Gym-Sudoku.py holds uv at ['==0.10.7'],
below 0.11.21. uv ships its list of installable Python builds inside the
release, so a uv this old has no cpython-3.13.14 to fetch and uv sync exits 2
with 'No interpreter found for Python 3.13.14 in managed installations or
search path' before the notebook gets anywhere. Pinning uv against a
compromised release is a reasonable thing to want, but it has to be a floor at
or above MIN_UV rather than a pin at a release that predates the interpreter,
and MIN_UV moves when Gym/.python-version moves.
```

### Testing

- `pytest tests/test_nemo_gym_uv_interpreter.py` -> 51 passed
- Verified the guard fires: temporarily rewrote `python_scripts/NeMo-Gym-Sudoku.py` to `uv==0.10.7` and got 1 failed / 50 passed with the message above, then reverted
- Full suite, `pytest tests/ --ignore=tests/security`: 144 failed / 16188 passed. Same 144 failures on a clean checkout of `main` (16179 passed there, the difference being the nine cases this PR adds). They are all in `test_molab_generation_parity.py` and `test_notebook_pin_consistency.py` and none of them mention NeMo Gym
