### PR TITLE
Verify the Node and cloudflared downloads in the molab Studio notebook

### DIFF
--- a/molab/Unsloth_Studio.py
+++ b/molab/Unsloth_Studio.py
@@ -51,6 +51,7 @@ def _(mo):
 
 @app.cell
 def _():
+    import hashlib
     import os
     import pathlib
     import re
@@ -60,6 +61,28 @@ def _():
     import tarfile
     import time
     import urllib.request
+
+    def _sha256(_path):
+        _digest = hashlib.sha256()
+        with open(_path, "rb") as _handle:
+            for _chunk in iter(lambda: _handle.read(1 << 20), b""):
+                _digest.update(_chunk)
+        return _digest.hexdigest()
+
+    def download_verified(_url, _dest, _sha):
+        # Only hand back bytes that hash to _sha. A good file on disk is
+        # kept, a bad or partial one is refetched, so reruns stay cheap.
+        if _dest.exists() and _sha256(_dest) == _sha:
+            return _dest
+        _dest.unlink(missing_ok=True)
+        urllib.request.urlretrieve(_url, _dest)
+        _got = _sha256(_dest)
+        if _got != _sha:
+            _dest.unlink(missing_ok=True)
+            raise RuntimeError(
+                f"Refusing to use {_url}: expected sha256 {_sha}, got {_got}"
+            )
+        return _dest
 
     # Grab the repo if it isn't here yet.
     if not pathlib.Path("unsloth").exists():
@@ -77,15 +100,23 @@ def _():
         )
     repo = pathlib.Path("unsloth").resolve()
 
-    # The UI ships unbuilt and there's no Node here, so fetch one to build with.
+    # The UI ships unbuilt and there's no Node here, so fetch one to build
+    # with. The SHA256 is the one nodejs.org publishes for this release, so
+    # a tampered mirror fails closed instead of landing on PATH.
     _node = pathlib.Path("node-v22.12.0-linux-x64")
     if not _node.exists():
-        _tar = pathlib.Path(f"{_node}.tar.xz")
-        urllib.request.urlretrieve(
-            f"https://nodejs.org/dist/v22.12.0/{_node}.tar.xz", _tar
+        _tar = download_verified(
+            f"https://nodejs.org/dist/v22.12.0/{_node}.tar.xz",
+            pathlib.Path(f"{_node}.tar.xz"),
+            "22982235e1b71fa8850f82edd09cdae7e3f32df1764a9ec298c72d25ef2c164f",
         )
         with tarfile.open(_tar) as _t:
-            _t.extractall()
+            # Reject members that escape the extraction dir. data_filter
+            # exists exactly where extractall(filter=) does.
+            if hasattr(tarfile, "data_filter"):
+                _t.extractall(filter="data")
+            else:
+                _t.extractall()
     os.environ["PATH"] = (
         str((_node / "bin").resolve()) + os.pathsep + os.environ["PATH"]
     )
@@ -94,18 +125,41 @@ def _():
     # no-venv path from a Colab-style env var; split the name so this file
     # stays marker-free. Drop when setup.sh learns molab.
     _hosted_tag = "COLAB" + "_RELEASE_TAG"
+    _setup = repo / "studio" / "setup.sh"
+    _setup.chmod(_setup.stat().st_mode | stat.S_IEXEC)
     subprocess.run(
-        "chmod +x studio/setup.sh && ./studio/setup.sh --local",
-        shell=True,
+        ["./studio/setup.sh", "--local"],
         check=True,
         cwd=str(repo),
         env={**os.environ, _hosted_tag: "molab"},
     )
-    return os, pathlib, re, repo, stat, subprocess, sys, time, urllib
+    return (
+        download_verified,
+        os,
+        pathlib,
+        re,
+        repo,
+        stat,
+        subprocess,
+        sys,
+        time,
+        urllib,
+    )
 
 
 @app.cell
-def _(os, pathlib, re, repo, stat, subprocess, sys, time, urllib):
+def _(
+    download_verified,
+    os,
+    pathlib,
+    re,
+    repo,
+    stat,
+    subprocess,
+    sys,
+    time,
+    urllib,
+):
     # Relax the server's frame headers before it starts so the page can
     # embed it below. Drop this once the backend reads UNSLOTH_STUDIO_EMBED.
     os.environ["UNSLOTH_STUDIO_EMBED"] = "1"
@@ -131,14 +185,15 @@ def _(os, pathlib, re, repo, stat, subprocess, sys, time, urllib):
             time.sleep(1)
 
     # Reach the server from the browser through a cloudflared quick tunnel
-    # (a public *.trycloudflare.com URL).
-    _cf = pathlib.Path("cloudflared")
-    if not _cf.exists():
-        urllib.request.urlretrieve(
-            "https://github.com/cloudflare/cloudflared/releases/latest"
-            "/download/cloudflared-linux-amd64",
-            _cf,
-        )
+    # (a public *.trycloudflare.com URL). releases/latest and its assets are
+    # both mutable, so pin the release and its SHA256 rather than chmod +x
+    # whatever came back. Bump the two together.
+    _cf = download_verified(
+        "https://github.com/cloudflare/cloudflared/releases/download/"
+        "2026.7.3/cloudflared-linux-amd64",
+        pathlib.Path("cloudflared-2026.7.3-linux-amd64"),
+        "9d71c677db00134c1bd4144b7783486b654ad281b1ea62b4972098d19f770f17",
+    )
     _cf.chmod(_cf.stat().st_mode | stat.S_IEXEC)
     _proc = subprocess.Popen(  # full path, else it won't be found
         [str(_cf.resolve()), "tunnel", "--url", "http://localhost:8888"],

--- a/molab/Unsloth_Studio.py
+++ b/molab/Unsloth_Studio.py
@@ -55,6 +55,7 @@ def _():
     import os
     import pathlib
     import re
+    import shutil
     import stat
     import subprocess
     import sys
@@ -104,12 +105,20 @@ def _():
     # with. The SHA256 is the one nodejs.org publishes for this release, so
     # a tampered mirror fails closed instead of landing on PATH.
     _node = pathlib.Path("node-v22.12.0-linux-x64")
-    if not _node.exists():
+    _node_sha = "22982235e1b71fa8850f82edd09cdae7e3f32df1764a9ec298c72d25ef2c164f"
+    # molab storage persists across sessions, so a tree may already be here
+    # from an earlier run, including the unverified download this replaces.
+    # Trust it only if it carries the hash we expect, else rebuild it.
+    _stamp = _node / ".verified-sha256"
+    if not _stamp.is_file() or _stamp.read_text().strip() != _node_sha:
         _tar = download_verified(
             f"https://nodejs.org/dist/v22.12.0/{_node}.tar.xz",
             pathlib.Path(f"{_node}.tar.xz"),
-            "22982235e1b71fa8850f82edd09cdae7e3f32df1764a9ec298c72d25ef2c164f",
+            _node_sha,
         )
+        # Only once the replacement is in hand, so a failed fetch cannot
+        # leave the runtime with no Node at all.
+        shutil.rmtree(_node, ignore_errors=True)
         with tarfile.open(_tar) as _t:
             # Reject members that escape the extraction dir. data_filter
             # exists exactly where extractall(filter=) does.
@@ -117,6 +126,7 @@ def _():
                 _t.extractall(filter="data")
             else:
                 _t.extractall()
+        _stamp.write_text(_node_sha)
     os.environ["PATH"] = (
         str((_node / "bin").resolve()) + os.pathsep + os.environ["PATH"]
     )

--- a/scripts/molab_generate.py
+++ b/scripts/molab_generate.py
@@ -1301,6 +1301,7 @@ def _studio_codes() -> list[str]:
         \"\"\")""")
 
     _install_cell = textwrap.dedent("""\
+        import hashlib
         import os
         import pathlib
         import re
@@ -1311,6 +1312,27 @@ def _studio_codes() -> list[str]:
         import time
         import urllib.request
 
+        def _sha256(_path):
+            _digest = hashlib.sha256()
+            with open(_path, "rb") as _handle:
+                for _chunk in iter(lambda: _handle.read(1 << 20), b""):
+                    _digest.update(_chunk)
+            return _digest.hexdigest()
+
+        def download_verified(_url, _dest, _sha):
+            # Only hand back bytes that hash to _sha. A good file on disk is
+            # kept, a bad or partial one is refetched, so reruns stay cheap.
+            if _dest.exists() and _sha256(_dest) == _sha:
+                return _dest
+            _dest.unlink(missing_ok=True)
+            urllib.request.urlretrieve(_url, _dest)
+            _got = _sha256(_dest)
+            if _got != _sha:
+                _dest.unlink(missing_ok=True)
+                raise RuntimeError(
+                    f"Refusing to use {_url}: expected sha256 {_sha}, got {_got}")
+            return _dest
+
         # Grab the repo if it isn't here yet.
         if not pathlib.Path("unsloth").exists():
             subprocess.run(
@@ -1320,23 +1342,34 @@ def _studio_codes() -> list[str]:
             )
         repo = pathlib.Path("unsloth").resolve()
 
-        # The UI ships unbuilt and there's no Node here, so fetch one to build with.
+        # The UI ships unbuilt and there's no Node here, so fetch one to build
+        # with. The SHA256 is the one nodejs.org publishes for this release, so
+        # a tampered mirror fails closed instead of landing on PATH.
         _node = pathlib.Path("node-v22.12.0-linux-x64")
         if not _node.exists():
-            _tar = pathlib.Path(f"{_node}.tar.xz")
-            urllib.request.urlretrieve(
-                f"https://nodejs.org/dist/v22.12.0/{_node}.tar.xz", _tar)
+            _tar = download_verified(
+                f"https://nodejs.org/dist/v22.12.0/{_node}.tar.xz",
+                pathlib.Path(f"{_node}.tar.xz"),
+                "22982235e1b71fa8850f82edd09cdae7e3f32df1764a9ec298c72d25ef2c164f",
+            )
             with tarfile.open(_tar) as _t:
-                _t.extractall()
+                # Reject members that escape the extraction dir. data_filter
+                # exists exactly where extractall(filter=) does.
+                if hasattr(tarfile, "data_filter"):
+                    _t.extractall(filter="data")
+                else:
+                    _t.extractall()
         os.environ["PATH"] = str((_node / "bin").resolve()) + os.pathsep + os.environ["PATH"]
 
         # Build the UI and install into system Python. setup.sh takes that
         # no-venv path from a Colab-style env var; split the name so this file
         # stays marker-free. Drop when setup.sh learns molab.
         _hosted_tag = "COLAB" + "_RELEASE_TAG"
+        _setup = repo / "studio" / "setup.sh"
+        _setup.chmod(_setup.stat().st_mode | stat.S_IEXEC)
         subprocess.run(
-            "chmod +x studio/setup.sh && ./studio/setup.sh --local",
-            shell=True, check=True, cwd=str(repo),
+            ["./studio/setup.sh", "--local"],
+            check=True, cwd=str(repo),
             env={**os.environ, _hosted_tag: "molab"},
         )""")
 
@@ -1361,12 +1394,15 @@ def _studio_codes() -> list[str]:
                 time.sleep(1)
 
         # Reach the server from the browser through a cloudflared quick tunnel
-        # (a public *.trycloudflare.com URL).
-        _cf = pathlib.Path("cloudflared")
-        if not _cf.exists():
-            urllib.request.urlretrieve(
-                "https://github.com/cloudflare/cloudflared/releases/latest"
-                "/download/cloudflared-linux-amd64", _cf)
+        # (a public *.trycloudflare.com URL). releases/latest and its assets are
+        # both mutable, so pin the release and its SHA256 rather than chmod +x
+        # whatever came back. Bump the two together.
+        _cf = download_verified(
+            "https://github.com/cloudflare/cloudflared/releases/download/"
+            "2026.7.3/cloudflared-linux-amd64",
+            pathlib.Path("cloudflared-2026.7.3-linux-amd64"),
+            "9d71c677db00134c1bd4144b7783486b654ad281b1ea62b4972098d19f770f17",
+        )
         _cf.chmod(_cf.stat().st_mode | stat.S_IEXEC)
         _proc = subprocess.Popen(  # full path, else it won't be found
             [str(_cf.resolve()), "tunnel", "--url", "http://localhost:8888"],

--- a/scripts/molab_generate.py
+++ b/scripts/molab_generate.py
@@ -1305,6 +1305,7 @@ def _studio_codes() -> list[str]:
         import os
         import pathlib
         import re
+        import shutil
         import stat
         import subprocess
         import sys
@@ -1346,12 +1347,18 @@ def _studio_codes() -> list[str]:
         # with. The SHA256 is the one nodejs.org publishes for this release, so
         # a tampered mirror fails closed instead of landing on PATH.
         _node = pathlib.Path("node-v22.12.0-linux-x64")
-        if not _node.exists():
+        _node_sha = "22982235e1b71fa8850f82edd09cdae7e3f32df1764a9ec298c72d25ef2c164f"
+        # molab storage persists across sessions, so a tree may already be here
+        # from an earlier run, including the unverified download this replaces.
+        # Trust it only if it carries the hash we expect, else rebuild it.
+        _stamp = _node / ".verified-sha256"
+        if not _stamp.is_file() or _stamp.read_text().strip() != _node_sha:
             _tar = download_verified(
                 f"https://nodejs.org/dist/v22.12.0/{_node}.tar.xz",
-                pathlib.Path(f"{_node}.tar.xz"),
-                "22982235e1b71fa8850f82edd09cdae7e3f32df1764a9ec298c72d25ef2c164f",
-            )
+                pathlib.Path(f"{_node}.tar.xz"), _node_sha)
+            # Only once the replacement is in hand, so a failed fetch cannot
+            # leave the runtime with no Node at all.
+            shutil.rmtree(_node, ignore_errors=True)
             with tarfile.open(_tar) as _t:
                 # Reject members that escape the extraction dir. data_filter
                 # exists exactly where extractall(filter=) does.
@@ -1359,6 +1366,7 @@ def _studio_codes() -> list[str]:
                     _t.extractall(filter="data")
                 else:
                     _t.extractall()
+            _stamp.write_text(_node_sha)
         os.environ["PATH"] = str((_node / "bin").resolve()) + os.pathsep + os.environ["PATH"]
 
         # Build the UI and install into system Python. setup.sh takes that


### PR DESCRIPTION
The molab Studio notebook is a bootstrapper: to get you a working Studio it downloads a Node.js toolchain and the `cloudflared` binary, then executes both. Neither download was checked against a known hash first.

HTTPS authenticates the server, not the artifact. A poisoned mirror, a hijacked redirect or a swapped release asset would have ended up on `PATH` or `chmod +x`'d and executed with the notebook user's privileges, which is where the Hugging Face token, the datasets and the trained adapters live.

Two concrete gaps:

- **Node** was fetched with no checksum and unpacked with a bare `tarfile.extractall()`. Bare `extractall` is the CVE-2007-4559 footgun: an archive can carry members with paths like `../../.ssh/authorized_keys` and Python will write them outside the destination directory.
- **cloudflared** came from `releases/latest`, which is a moving target by design, and GitHub release assets can be replaced in place on an existing release too. Whatever bytes came back were marked executable and run.

### What changed

Both downloads now go through a small `download_verified()` helper that pins a SHA256 and refuses anything that does not match.

- Node keeps its existing `v22.12.0` pin and gains the SHA256 that `nodejs.org/dist/v22.12.0/SHASUMS256.txt` publishes for it.
- Extraction uses `filter="data"` where the interpreter has it, guarded by `hasattr(tarfile, "data_filter")` so the older 3.10 patch levels in `requires-python` still work. Members that would escape the extraction directory are rejected.
- cloudflared is pinned to `2026.7.3` plus its SHA256, stored under a versioned filename.
- `studio/setup.sh` is invoked as an argument list instead of a `shell=True` string.

`download_verified()` keeps a file that already hashes correctly, replaces one that does not, and removes partial downloads, so reruns after a crash stay cheap and do the right thing.

Changes were made in `scripts/molab_generate.py` and `molab/Unsloth_Studio.py` regenerated from it, since `tests/test_molab_generation_parity.py` enforces byte-identical regeneration.

### What did not change, on purpose

The clone of `unslothai/unsloth` deliberately stays on `main`.

Pinning it to a commit would freeze molab users on a stale Studio until someone hand-bumped the notebook on every release, which breaks the flow the notebook exists to provide. It also would not buy much: a pin living in this repo does not defend against a compromise of the repo the notebook is there to deliver in the first place.

### No user-visible change

The flow is identical: hit Run all, wait, get a `*.trycloudflare.com` link and the embedded Studio. Same cells, same order, same output, same sign-in note. Nothing new to click, install or configure.

The only new behaviour is a failure mode that did not exist before. If a hash does not match you get `Refusing to use <url>: expected sha256 ..., got ...` rather than the notebook quietly building on a tampered artifact.

### Verification

Run rather than reasoned about:

- Node tarball downloaded, hash matched the published `SHASUMS256.txt`, extracted under `filter="data"`. The `npm` symlink survived, `node -v` gives `v22.12.0`, `npm -v` gives `10.9.0`. The `data` filter strips setuid/setgid and group/other-write bits but leaves owner-execute alone, which is all Node needs.
- cloudflared `2026.7.3` downloaded, hash matched, `--version` runs. The `--url` quick tunnel flag is unchanged.
- `studio/setup.sh` carries `#!/usr/bin/env bash` and is committed `100755`, so the argument-list form is behaviourally identical to the old shell string, which relied on the same shebang.
- `python scripts/molab_generate.py --check` exits 0. A full regeneration of every molab notebook touches only `Unsloth_Studio.py`.
- Targeted molab suite green: 4396 passed, 25 skipped across `test_molab_generation_parity`, `test_molab_marimo_validity`, `test_molab_no_colab_markers`, `test_molab_manifest`, `test_molab_templated_pins`, `test_molab_dependency_parity`, `test_no_backgrounded_shell_command` and `test_live_names_bound_only_in_dead_code`.
- Tampering with a file makes `download_verified()` raise and remove the partial, confirmed directly.

### One maintenance note

The cloudflared pin needs an occasional bump. Cloudflare ships often and eventually retires very old clients, so this is worth folding into whatever pin refresh we already run for the other notebooks. The Node pin has no such cost, since that tarball is immutable and the version was already hardcoded.
