### PR TITLE
Register the Muse Glimmer trl pin with the pin-consistency gate

### DIFF
--- a/tests/test_notebook_pin_consistency.py
+++ b/tests/test_notebook_pin_consistency.py
@@ -57,6 +57,14 @@ _KNOWN_PIN_OUTLIERS: set[tuple[str, str, str]] = {
     ("nb/Qwen3_VL_(8B)-Vision-GRPO.ipynb", "trl", "0.26.2"),
     # Minted from the nb/ copy above, so it inherits that pin.
     ("nb/AMD-Qwen3_VL_(8B)-Vision-GRPO.ipynb", "trl", "0.26.2"),
+    # Muse Glimmer needs the device map planner and the GRPO log-softmax fix,
+    # which are in trl 1.9.2 and in no release the canonical pin can move to
+    # without dragging every other notebook along. The template carries the
+    # pin, and the three generated copies inherit it.
+    ("original_template/Muse_Glimmer_(30B)-GRPO.ipynb", "trl", "1.9.2"),
+    ("nb/Muse_Glimmer_(30B)-GRPO.ipynb", "trl", "1.9.2"),
+    ("nb/Kaggle-Muse_Glimmer_(30B)-GRPO.ipynb", "trl", "1.9.2"),
+    ("nb/HuggingFace Course-Muse_Glimmer_(30B)-GRPO.ipynb", "trl", "1.9.2"),
 }
 
 


### PR DESCRIPTION
## Problem

The `notebook static checks (HARD GATE)` job has been failing on `main` since the Muse Glimmer notebooks landed, and therefore on every PR opened against it. Latest `main` run: https://github.com/unslothai/notebooks/actions/runs/31487197207

```
DRIFT DETECTED: nb/Muse_Glimmer_(30B)-GRPO.ipynb pins package versions that are not in
the generator's canonical / override pin set:
    cell 5: trl==1.9.2
Canonical PIN_* constants: transformers==4.56.2, trl==0.22.2
```

Four notebooks trip it: the template plus the three generated copies (`nb/`, `nb/Kaggle-`, `nb/HuggingFace Course-`).

## Why the pin is right

The Muse Glimmer install cell pins `trl==1.9.2` on purpose, for the device map planner and the GRPO log-softmax fix, and says so in its own comment. Moving canonical `PIN_TRL` to 1.9.2 would drag every other notebook along, and the pin is not produced by a per-model override branch in `update_all_notebooks.py`, so the gate has nowhere to find it.

`_KNOWN_PIN_OUTLIERS` in `tests/test_notebook_pin_consistency.py` is exactly the register for a deliberate notebook specific pin, and already holds the Whisper, Openenv wordle and Qwen3 VL GRPO entries. This adds the four Muse Glimmer paths next to them, with a comment saying why.

## Result

No notebook changes, no generator changes, test-registration only.

```
python -m pytest tests/test_notebook_json_validity.py tests/test_notebook_pin_consistency.py tests/test_notebook_amd_install_parity.py -q
2531 passed
```

That is the full set the hard gate job runs. On `main` without this change the same command is `4 failed, 553 passed` on the pin gate.
