### PR TITLE
Grandfather the Muse Glimmer GRPO trl pin in the pin-consistency gate

### DIFF
--- a/tests/test_notebook_pin_consistency.py
+++ b/tests/test_notebook_pin_consistency.py
@@ -57,6 +57,14 @@ _KNOWN_PIN_OUTLIERS: set[tuple[str, str, str]] = {
     ("nb/Qwen3_VL_(8B)-Vision-GRPO.ipynb", "trl", "0.26.2"),
     # Minted from the nb/ copy above, so it inherits that pin.
     ("nb/AMD-Qwen3_VL_(8B)-Vision-GRPO.ipynb", "trl", "0.26.2"),
+    # The Muse Glimmer GRPO cell installs unsloth and unsloth_zoo from git for
+    # the GRPO log-softmax fix, and pins the matching trl. The generator only
+    # swaps the transformers pin for muse_glimmer, so the trl pin lives in the
+    # notebook and has no counterpart in update_all_notebooks.py.
+    ("original_template/Muse_Glimmer_(30B)-GRPO.ipynb", "trl", "1.9.2"),
+    ("nb/Muse_Glimmer_(30B)-GRPO.ipynb", "trl", "1.9.2"),
+    ("nb/Kaggle-Muse_Glimmer_(30B)-GRPO.ipynb", "trl", "1.9.2"),
+    ("nb/HuggingFace Course-Muse_Glimmer_(30B)-GRPO.ipynb", "trl", "1.9.2"),
 }
 
 


### PR DESCRIPTION
### What this fixes

`notebook static checks (HARD GATE)` has been red on `main` since #341, with 4 failures in `tests/test_notebook_pin_consistency.py`:

```
DRIFT DETECTED: nb/Muse_Glimmer_(30B)-GRPO.ipynb pins package versions that are not in
the generator's canonical / override pin set:
    cell 5: trl==1.9.2
```

The same failure hits the template and all three generated copies. Latest red run on `main`: [31487197207](https://github.com/unslothai/notebooks/actions/runs/31487197207).

### Why it drifts

The Muse Glimmer GRPO install cell pins `trl==1.9.2` alongside the git installs of `unsloth` and `unsloth_zoo` that carry the GRPO log-softmax fix. For `muse_glimmer` the generator only swaps the `transformers` pin, so that `trl` pin lives in the notebook and has no counterpart in `update_all_notebooks.py`. The gate is reading it correctly, there is nothing in the generator for it to match.

### The fix

Grandfather the four paths in `_KNOWN_PIN_OUTLIERS`, exactly how the other hand-maintained GRPO notebooks are handled there already (`Openenv_wordle_grpo` at `trl==0.29.1`, `Qwen3_VL_(8B)-Vision-GRPO` at `trl==0.26.2`). The pin itself is correct and stays as is, `1.9.2` is the current trl release.

### Checks

- `tests/test_notebook_pin_consistency.py`: 557 passed.
- Every other test the hard gate runs passes: JSON validity 1668, AMD install parity 306, NeMo Gym 72, synthetic data 5.
- Full `tests/` suite: 16505 passed, 569 skipped, 0 failures, with `marimo==0.23.8` and `ruff==0.15.16` matched to CI.
- No notebook or generator content changes, this only touches the gate's outlier list.
