### PR TITLE
Tidy the Qwen3.8 (27B) notebook

### DIFF
--- a/nb/Kaggle-Qwen3.8_(27B)-Conversational.ipynb
+++ b/nb/Kaggle-Qwen3.8_(27B)-Conversational.ipynb
@@ -54,7 +54,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "%%capture\nimport os\n\n!pip install --upgrade -qqq uv\ntry: import numpy, PIL; _numpy = f'numpy=={numpy.__version__}'; _pil = f'pillow=={PIL.__version__}'\nexcept: _numpy = \"numpy\"; _pil = \"pillow\"\n# Pin Kaggle's preinstalled torch and torchvision instead of upgrading them.\n# `--upgrade torchvision` pulls a CUDA 13.0 torch on top of Kaggle's CUDA 12.8\n# torchaudio, and torchaudio then refuses to import: \"PyTorch and TorchAudio were\n# compiled with different CUDA versions\". Pin on the base version, not\n# torch.__version__, so the local +cu128 label does not have to exist on the index;\n# PEP 440 treats 2.9.1+cu128 as satisfying ==2.9.1.\ntry:\n    import torch, torchvision\n    _torch = f'torch=={torch.__version__.split(\"+\")[0]}'\n    _tv = f'torchvision=={torchvision.__version__.split(\"+\")[0]}'\nexcept Exception:\n    _torch, _tv = \"torch\", \"torchvision\"\n!uv pip install -qqq {_numpy} {_pil} {_torch} {_tv} bitsandbytes xformers unsloth\n!uv pip install -qqq triton \"huggingface_hub>=0.34.0\" \"datasets==4.3.0\"\n!uv pip install -qqq --no-deps --upgrade \"torchao>=0.16.0\"\n!uv pip install -qqq transformers==5.15.1\n!uv pip install -qqq --no-deps trl==0.22.2\n"
+   "source": "%%capture\nimport os\n\n!pip install --upgrade -qqq uv\ntry: import numpy, PIL; _numpy = f'numpy=={numpy.__version__}'; _pil = f'pillow=={PIL.__version__}'\nexcept: _numpy = \"numpy\"; _pil = \"pillow\"\n# Pin Kaggle's torch and torchvision: upgrading them pulls a CUDA 13.0 torch onto\n# Kaggle's CUDA 12.8 torchaudio, which then refuses to import. Pin the base version,\n# since the local +cu128 label does not exist on the index.\ntry:\n    import torch, torchvision\n    _torch = f'torch=={torch.__version__.split(\"+\")[0]}'\n    _tv = f'torchvision=={torchvision.__version__.split(\"+\")[0]}'\nexcept Exception:\n    _torch, _tv = \"torch\", \"torchvision\"\n!uv pip install -qqq {_numpy} {_pil} {_torch} {_tv} bitsandbytes xformers unsloth\n!uv pip install -qqq triton \"huggingface_hub>=0.34.0\" \"datasets==4.3.0\"\n!uv pip install -qqq --no-deps --upgrade \"torchao>=0.16.0\"\n!uv pip install -qqq transformers==5.15.1\n!uv pip install -qqq --no-deps trl==0.22.2"
   },
   {
    "cell_type": "markdown",
@@ -80,17 +80,6 @@
     "not pass `device_map` - unsloth's `\"sequential\"` default fills one card then the other.\n",
     "`\"balanced\"` looks right and is not: it caps cuda:0 below cuda:1, leaves the 2.37 GiB\n",
     "`lm_head` without a home, and bitsandbytes then refuses the CPU entry."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "`unsloth/Qwen3.8-27B` with `load_in_4bit` resolves to\n",
-    "[`unsloth/Qwen3.8-27B-unsloth-bnb-4bit`](https://huggingface.co/unsloth/Qwen3.8-27B-unsloth-bnb-4bit):\n",
-    "nf4, with `lm_head`, `embed_tokens`, the vision tower and the gated delta net's\n",
-    "`in_proj_qkv` / `in_proj_a` / `in_proj_b` left in float16. GGUFs are at\n",
-    "[`unsloth/Qwen3.8-27B-GGUF`](https://huggingface.co/unsloth/Qwen3.8-27B-GGUF)."
    ]
   },
   {
@@ -435,11 +424,7 @@
    "source": [
     "from unsloth.chat_templates import train_on_responses_only\n",
     "\n",
-    "trainer = train_on_responses_only(\n",
-    "    trainer,\n",
-    "    instruction_part = \"<|im_start|>user\\n\",\n",
-    "    response_part    = \"<|im_start|>assistant\\n\",\n",
-    ")"
+    "trainer = train_on_responses_only(trainer)"
    ]
   },
   {

--- a/nb/Qwen3.8_(27B)-Conversational.ipynb
+++ b/nb/Qwen3.8_(27B)-Conversational.ipynb
@@ -83,17 +83,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "`unsloth/Qwen3.8-27B` with `load_in_4bit` resolves to\n",
-    "[`unsloth/Qwen3.8-27B-unsloth-bnb-4bit`](https://huggingface.co/unsloth/Qwen3.8-27B-unsloth-bnb-4bit):\n",
-    "nf4, with `lm_head`, `embed_tokens`, the vision tower and the gated delta net's\n",
-    "`in_proj_qkv` / `in_proj_a` / `in_proj_b` left in float16. GGUFs are at\n",
-    "[`unsloth/Qwen3.8-27B-GGUF`](https://huggingface.co/unsloth/Qwen3.8-27B-GGUF)."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -435,11 +424,7 @@
    "source": [
     "from unsloth.chat_templates import train_on_responses_only\n",
     "\n",
-    "trainer = train_on_responses_only(\n",
-    "    trainer,\n",
-    "    instruction_part = \"<|im_start|>user\\n\",\n",
-    "    response_part    = \"<|im_start|>assistant\\n\",\n",
-    ")"
+    "trainer = train_on_responses_only(trainer)"
    ]
   },
   {

--- a/original_template/Qwen3.8_(27B)-Conversational.ipynb
+++ b/original_template/Qwen3.8_(27B)-Conversational.ipynb
@@ -87,17 +87,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "`unsloth/Qwen3.8-27B` with `load_in_4bit` resolves to\n",
-    "[`unsloth/Qwen3.8-27B-unsloth-bnb-4bit`](https://huggingface.co/unsloth/Qwen3.8-27B-unsloth-bnb-4bit):\n",
-    "nf4, with `lm_head`, `embed_tokens`, the vision tower and the gated delta net's\n",
-    "`in_proj_qkv` / `in_proj_a` / `in_proj_b` left in float16. GGUFs are at\n",
-    "[`unsloth/Qwen3.8-27B-GGUF`](https://huggingface.co/unsloth/Qwen3.8-27B-GGUF)."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -439,11 +428,7 @@
    "source": [
     "from unsloth.chat_templates import train_on_responses_only\n",
     "\n",
-    "trainer = train_on_responses_only(\n",
-    "    trainer,\n",
-    "    instruction_part = \"<|im_start|>user\\n\",\n",
-    "    response_part    = \"<|im_start|>assistant\\n\",\n",
-    ")"
+    "trainer = train_on_responses_only(trainer)"
    ]
   },
   {

--- a/python_scripts/Kaggle-Qwen3.8_(27B)-Conversational.py
+++ b/python_scripts/Kaggle-Qwen3.8_(27B)-Conversational.py
@@ -33,7 +33,7 @@
 # # In[ ]:
 # 
 # 
-# get_ipython().run_cell_magic('capture', '', 'import os\n\n!pip install --upgrade -qqq uv\ntry: import numpy, PIL; _numpy = f\'numpy=={numpy.__version__}\'; _pil = f\'pillow=={PIL.__version__}\'\nexcept: _numpy = "numpy"; _pil = "pillow"\n# Pin Kaggle\'s preinstalled torch and torchvision instead of upgrading them.\n# `--upgrade torchvision` pulls a CUDA 13.0 torch on top of Kaggle\'s CUDA 12.8\n# torchaudio, and torchaudio then refuses to import: "PyTorch and TorchAudio were\n# compiled with different CUDA versions". Pin on the base version, not\n# torch.__version__, so the local +cu128 label does not have to exist on the index;\n# PEP 440 treats 2.9.1+cu128 as satisfying ==2.9.1.\ntry:\n    import torch, torchvision\n    _torch = f\'torch=={torch.__version__.split("+")[0]}\'\n    _tv = f\'torchvision=={torchvision.__version__.split("+")[0]}\'\nexcept Exception:\n    _torch, _tv = "torch", "torchvision"\n!uv pip install -qqq {_numpy} {_pil} {_torch} {_tv} bitsandbytes xformers unsloth\n!uv pip install -qqq triton "huggingface_hub>=0.34.0" "datasets==4.3.0"\n!uv pip install -qqq --no-deps --upgrade "torchao>=0.16.0"\n!uv pip install -qqq transformers==5.15.1\n!uv pip install -qqq --no-deps trl==0.22.2\n')
+# get_ipython().run_cell_magic('capture', '', 'import os\n\n!pip install --upgrade -qqq uv\ntry: import numpy, PIL; _numpy = f\'numpy=={numpy.__version__}\'; _pil = f\'pillow=={PIL.__version__}\'\nexcept: _numpy = "numpy"; _pil = "pillow"\n# Pin Kaggle\'s torch and torchvision: upgrading them pulls a CUDA 13.0 torch onto\n# Kaggle\'s CUDA 12.8 torchaudio, which then refuses to import. Pin the base version,\n# since the local +cu128 label does not exist on the index.\ntry:\n    import torch, torchvision\n    _torch = f\'torch=={torch.__version__.split("+")[0]}\'\n    _tv = f\'torchvision=={torchvision.__version__.split("+")[0]}\'\nexcept Exception:\n    _torch, _tv = "torch", "torchvision"\n!uv pip install -qqq {_numpy} {_pil} {_torch} {_tv} bitsandbytes xformers unsloth\n!uv pip install -qqq triton "huggingface_hub>=0.34.0" "datasets==4.3.0"\n!uv pip install -qqq --no-deps --upgrade "torchao>=0.16.0"\n!uv pip install -qqq transformers==5.15.1\n!uv pip install -qqq --no-deps trl==0.22.2\n')
 # 
 # 
 # # ### Unsloth
@@ -51,12 +51,6 @@
 # not pass `device_map` - unsloth's `"sequential"` default fills one card then the other.
 # `"balanced"` looks right and is not: it caps cuda:0 below cuda:1, leaves the 2.37 GiB
 # `lm_head` without a home, and bitsandbytes then refuses the CPU entry.
-
-# `unsloth/Qwen3.8-27B` with `load_in_4bit` resolves to
-# [`unsloth/Qwen3.8-27B-unsloth-bnb-4bit`](https://huggingface.co/unsloth/Qwen3.8-27B-unsloth-bnb-4bit):
-# nf4, with `lm_head`, `embed_tokens`, the vision tower and the gated delta net's
-# `in_proj_qkv` / `in_proj_a` / `in_proj_b` left in float16. GGUFs are at
-# [`unsloth/Qwen3.8-27B-GGUF`](https://huggingface.co/unsloth/Qwen3.8-27B-GGUF).
 
 # In[ ]:
 
@@ -311,11 +305,7 @@ trainer = SFTTrainer(
 
 from unsloth.chat_templates import train_on_responses_only
 
-trainer = train_on_responses_only(
-    trainer,
-    instruction_part = "<|im_start|>user\n",
-    response_part    = "<|im_start|>assistant\n",
-)
+trainer = train_on_responses_only(trainer)
 
 
 # Let's verify masking the instruction part is done. Row 100, then the same row with

--- a/python_scripts/Qwen3.8_(27B)-Conversational.py
+++ b/python_scripts/Qwen3.8_(27B)-Conversational.py
@@ -52,12 +52,6 @@
 # `"balanced"` looks right and is not: it caps cuda:0 below cuda:1, leaves the 2.37 GiB
 # `lm_head` without a home, and bitsandbytes then refuses the CPU entry.
 
-# `unsloth/Qwen3.8-27B` with `load_in_4bit` resolves to
-# [`unsloth/Qwen3.8-27B-unsloth-bnb-4bit`](https://huggingface.co/unsloth/Qwen3.8-27B-unsloth-bnb-4bit):
-# nf4, with `lm_head`, `embed_tokens`, the vision tower and the gated delta net's
-# `in_proj_qkv` / `in_proj_a` / `in_proj_b` left in float16. GGUFs are at
-# [`unsloth/Qwen3.8-27B-GGUF`](https://huggingface.co/unsloth/Qwen3.8-27B-GGUF).
-
 # In[ ]:
 
 
@@ -311,11 +305,7 @@ trainer = SFTTrainer(
 
 from unsloth.chat_templates import train_on_responses_only
 
-trainer = train_on_responses_only(
-    trainer,
-    instruction_part = "<|im_start|>user\n",
-    response_part    = "<|im_start|>assistant\n",
-)
+trainer = train_on_responses_only(trainer)
 
 
 # Let's verify masking the instruction part is done. Row 100, then the same row with

--- a/update_all_notebooks.py
+++ b/update_all_notebooks.py
@@ -955,12 +955,9 @@ import os
 !pip install --upgrade -qqq uv
 try: import numpy, PIL; _numpy = f'numpy=={numpy.__version__}'; _pil = f'pillow=={PIL.__version__}'
 except: _numpy = "numpy"; _pil = "pillow"
-# Pin Kaggle's preinstalled torch and torchvision instead of upgrading them.
-# `--upgrade torchvision` pulls a CUDA 13.0 torch on top of Kaggle's CUDA 12.8
-# torchaudio, and torchaudio then refuses to import: "PyTorch and TorchAudio were
-# compiled with different CUDA versions". Pin on the base version, not
-# torch.__version__, so the local +cu128 label does not have to exist on the index;
-# PEP 440 treats 2.9.1+cu128 as satisfying ==2.9.1.
+# Pin Kaggle's torch and torchvision: upgrading them pulls a CUDA 13.0 torch onto
+# Kaggle's CUDA 12.8 torchaudio, which then refuses to import. Pin the base version,
+# since the local +cu128 label does not exist on the index.
 try:
     import torch, torchvision
     _torch = f'torch=={torch.__version__.split("+")[0]}'
@@ -971,8 +968,7 @@ except Exception:
 !uv pip install -qqq triton "huggingface_hub>=0.34.0" "datasets==4.3.0"
 !uv pip install -qqq --no-deps --upgrade "torchao>=0.16.0"
 !uv pip install -qqq transformers==5.15.1
-!uv pip install -qqq --no-deps trl==0.22.2
-"""
+!uv pip install -qqq --no-deps trl==0.22.2"""
 
 # A wheel, not a source build of `main`: every sglang release pins ONE exact
 # transformers, so cloning main and then forcing transformers==4.53.0 left the


### PR DESCRIPTION
### Summary

Four small cleanups to the Qwen3.8-27B notebook, all generated from `original_template/` plus `update_all_notebooks.py` rather than edited by hand.

- **`train_on_responses_only(trainer)`**, dropping the explicit `instruction_part` and `response_part`. Both already default to `None` and are found from the chat template.
- **Removed the repo-layout markdown cell.** It restated what the model card says.
- **Shortened the Kaggle torch pin comment** from six lines to three.
- **Removed a trailing newline** that left a blank last line in the Kaggle install cell. The Colab variant never had it, so this makes the two match.

### Verification

The short `train_on_responses_only` call is the only change with behaviour behind it, so I checked the masking rather than assuming the default works for this template. Running the notebook's own verification cell, the instruction is blanked and only the assistant turn survives in the labels:

```
==============================
                                        In programming, the modulus operator is
represented by the '%' symbol. It calculates the remainder when one number is
divided by another. ...
```

That is the same masking the explicit parts produced. Full notebook run to completion locally, exit 0.

For the trailing newline, the first code cell's source now ends `'2'` rather than `'.2\n'` in both the Kaggle and Colab notebooks.

### Context

The notebook as merged in #361 was confirmed on a real Kaggle 2 x T4 kernel against main unsloth and main unsloth-zoo: 22 of 22 code cells clean, 538.0 s for five steps, 12.834 and 12.801 GB peak reserved of 14.562, with `loading from: unsloth/Qwen3.8-27B` and `multi-GPU load workaround not needed` both confirming the merged fixes are doing their job. This PR sits on top of that.
