### PR TITLE
Use the library sandbox helper in the matmul GRPO notebooks

### DIFF
--- a/molab/Gemma4_(E2B)_GRPO.py
+++ b/molab/Gemma4_(E2B)_GRPO.py
@@ -31,7 +31,7 @@
 
 import marimo
 
-__generated_with = "0.23.8"
+__generated_with = "0.24.0"
 app = marimo.App()
 
 
@@ -428,17 +428,15 @@ def _(np, output_function):
         import_numpy()
     except Exception as e:
         print(str(e))
-    return (types,)
+    return
 
 
 @app.cell
-def _(types):
-    def create_locked_down_function(function):
-        output_function = {}
-        exec(function, {}, output_function)
-        new_matmul = output_function["matmul"]
-        new_matmul = types.FunctionType(new_matmul.__code__, {})
-        return new_matmul
+def _():
+    # Unsloth's create_locked_down_function executes the generated code with a
+    # restricted set of builtins and a restricted importer, so a reward hacking
+    # completion cannot reach os, subprocess, sockets or the filesystem.
+    from unsloth import create_locked_down_function
 
     return (create_locked_down_function,)
 

--- a/molab/Gemma4_(E2B)_GRPO.py
+++ b/molab/Gemma4_(E2B)_GRPO.py
@@ -31,7 +31,7 @@
 
 import marimo
 
-__generated_with = "0.24.0"
+__generated_with = "0.23.8"
 app = marimo.App()
 
 

--- a/molab/gpt-oss-(20B)-GRPO.py
+++ b/molab/gpt-oss-(20B)-GRPO.py
@@ -27,7 +27,7 @@
 
 import marimo
 
-__generated_with = "0.23.8"
+__generated_with = "0.24.0"
 app = marimo.App()
 
 
@@ -74,12 +74,9 @@ def _(mo):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    Introducing **Unsloth Studio** - a new open source, no-code web UI to train and run LLMs. [Blog](https://unsloth.ai/docs/new/studio) • [Notebook](https://github.com/unslothai/unsloth/blob/main/studio/Unsloth_Studio_Colab.ipynb)
+    Introducing **[Unsloth Desktop](https://unsloth.ai/docs/desktop)**, the first desktop app to run and train models. Free and open-source for macOS, Windows and Linux. [GitHub](https://github.com/unslothai/unsloth) • [Download](https://unsloth.ai/download)
 
-    <table><tr>
-    <td align="center"><a href="https://unsloth.ai/docs/new/studio"><img src="https://unsloth.ai/docs/~gitbook/image?url=https%3A%2F%2F3215535692-files.gitbook.io%2F~%2Ffiles%2Fv0%2Fb%2Fgitbook-x-prod.appspot.com%2Fo%2Fspaces%252FxhOjnexMCB3dmuQFQ2Zq%252Fuploads%252FxV1PO5DbF3ksB51nE2Tw%252Fmore%2520cropped%2520ui%2520for%2520homepage.png%3Falt%3Dmedia%26token%3Df75942c9-3d8d-4b59-8ba2-1a4a38de1b86&width=376&dpr=3&quality=100&sign=a663c397&sv=2" width="200" height="120" alt="Unsloth Studio Training UI"></a><br><sub><b>Train models</b> — no code needed</sub></td>
-    <td align="center"><a href="https://unsloth.ai/docs/new/studio"><img src="https://unsloth.ai/docs/~gitbook/image?url=https%3A%2F%2F3215535692-files.gitbook.io%2F~%2Ffiles%2Fv0%2Fb%2Fgitbook-x-prod.appspot.com%2Fo%2Fspaces%252FxhOjnexMCB3dmuQFQ2Zq%252Fuploads%252FRCnTAZ6Uh88DIlU3g0Ij%252Fmainpage%2520unsloth.png%3Falt%3Dmedia%26token%3D837c96b6-bd09-4e81-bc76-fa50421e9bfb&width=376&dpr=3&quality=100&sign=c1a39da1&sv=2" width="200" height="120" alt="Unsloth Studio Chat UI"></a><br><sub><b>Run GGUF models</b> on Mac, Windows & Linux</sub></td>
-    </tr></table>
+    <a href="https://unsloth.ai/docs/desktop"><img src="https://raw.githubusercontent.com/unslothai/notebooks/refs/heads/main/assets/unsloth-qwen3-8.png" width="350" alt="Introducing Unsloth Desktop"></a>
 
     Train MoEs - DeepSeek, GLM, Qwen and gpt-oss 12x faster with 35% less VRAM. [Blog](https://unsloth.ai/docs/new/faster-moe)
 
@@ -454,17 +451,15 @@ def _(np, output_function):
         import_numpy()
     except Exception as e:
         print(str(e))
-    return (types,)
+    return
 
 
 @app.cell
-def _(types):
-    def create_locked_down_function(function):
-        output_function = {}
-        exec(function, {}, output_function)
-        new_matmul = output_function["matmul"]
-        new_matmul = types.FunctionType(new_matmul.__code__, {})
-        return new_matmul
+def _():
+    # Unsloth's create_locked_down_function executes the generated code with a
+    # restricted set of builtins and a restricted importer, so a reward hacking
+    # completion cannot reach os, subprocess, sockets or the filesystem.
+    from unsloth import create_locked_down_function
 
     return (create_locked_down_function,)
 

--- a/molab/gpt-oss-(20B)-GRPO.py
+++ b/molab/gpt-oss-(20B)-GRPO.py
@@ -27,7 +27,7 @@
 
 import marimo
 
-__generated_with = "0.24.0"
+__generated_with = "0.23.8"
 app = marimo.App()
 
 

--- a/molab/gpt-oss-(20B)_A100-GRPO.py
+++ b/molab/gpt-oss-(20B)_A100-GRPO.py
@@ -27,7 +27,7 @@
 
 import marimo
 
-__generated_with = "0.23.8"
+__generated_with = "0.24.0"
 app = marimo.App()
 
 
@@ -74,12 +74,9 @@ def _(mo):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    Introducing **Unsloth Studio** - a new open source, no-code web UI to train and run LLMs. [Blog](https://unsloth.ai/docs/new/studio) • [Notebook](https://github.com/unslothai/unsloth/blob/main/studio/Unsloth_Studio_Colab.ipynb)
+    Introducing **[Unsloth Desktop](https://unsloth.ai/docs/desktop)**, the first desktop app to run and train models. Free and open-source for macOS, Windows and Linux. [GitHub](https://github.com/unslothai/unsloth) • [Download](https://unsloth.ai/download)
 
-    <table><tr>
-    <td align="center"><a href="https://unsloth.ai/docs/new/studio"><img src="https://unsloth.ai/docs/~gitbook/image?url=https%3A%2F%2F3215535692-files.gitbook.io%2F~%2Ffiles%2Fv0%2Fb%2Fgitbook-x-prod.appspot.com%2Fo%2Fspaces%252FxhOjnexMCB3dmuQFQ2Zq%252Fuploads%252FxV1PO5DbF3ksB51nE2Tw%252Fmore%2520cropped%2520ui%2520for%2520homepage.png%3Falt%3Dmedia%26token%3Df75942c9-3d8d-4b59-8ba2-1a4a38de1b86&width=376&dpr=3&quality=100&sign=a663c397&sv=2" width="200" height="120" alt="Unsloth Studio Training UI"></a><br><sub><b>Train models</b> — no code needed</sub></td>
-    <td align="center"><a href="https://unsloth.ai/docs/new/studio"><img src="https://unsloth.ai/docs/~gitbook/image?url=https%3A%2F%2F3215535692-files.gitbook.io%2F~%2Ffiles%2Fv0%2Fb%2Fgitbook-x-prod.appspot.com%2Fo%2Fspaces%252FxhOjnexMCB3dmuQFQ2Zq%252Fuploads%252FRCnTAZ6Uh88DIlU3g0Ij%252Fmainpage%2520unsloth.png%3Falt%3Dmedia%26token%3D837c96b6-bd09-4e81-bc76-fa50421e9bfb&width=376&dpr=3&quality=100&sign=c1a39da1&sv=2" width="200" height="120" alt="Unsloth Studio Chat UI"></a><br><sub><b>Run GGUF models</b> on Mac, Windows & Linux</sub></td>
-    </tr></table>
+    <a href="https://unsloth.ai/docs/desktop"><img src="https://raw.githubusercontent.com/unslothai/notebooks/refs/heads/main/assets/unsloth-qwen3-8.png" width="350" alt="Introducing Unsloth Desktop"></a>
 
     Train MoEs - DeepSeek, GLM, Qwen and gpt-oss 12x faster with 35% less VRAM. [Blog](https://unsloth.ai/docs/new/faster-moe)
 
@@ -454,17 +451,15 @@ def _(np, output_function):
         import_numpy()
     except Exception as e:
         print(str(e))
-    return (types,)
+    return
 
 
 @app.cell
-def _(types):
-    def create_locked_down_function(function):
-        output_function = {}
-        exec(function, {}, output_function)
-        new_matmul = output_function["matmul"]
-        new_matmul = types.FunctionType(new_matmul.__code__, {})
-        return new_matmul
+def _():
+    # Unsloth's create_locked_down_function executes the generated code with a
+    # restricted set of builtins and a restricted importer, so a reward hacking
+    # completion cannot reach os, subprocess, sockets or the filesystem.
+    from unsloth import create_locked_down_function
 
     return (create_locked_down_function,)
 

--- a/molab/gpt-oss-(20B)_A100-GRPO.py
+++ b/molab/gpt-oss-(20B)_A100-GRPO.py
@@ -27,7 +27,7 @@
 
 import marimo
 
-__generated_with = "0.24.0"
+__generated_with = "0.23.8"
 app = marimo.App()
 
 

--- a/molab/gpt_oss_(20B)_GRPO_BF16.py
+++ b/molab/gpt_oss_(20B)_GRPO_BF16.py
@@ -27,7 +27,7 @@
 
 import marimo
 
-__generated_with = "0.23.8"
+__generated_with = "0.24.0"
 app = marimo.App()
 
 
@@ -66,12 +66,9 @@ def _(mo):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    Introducing **Unsloth Studio** - a new open source, no-code web UI to train and run LLMs. [Blog](https://unsloth.ai/docs/new/studio) • [Notebook](https://github.com/unslothai/unsloth/blob/main/studio/Unsloth_Studio_Colab.ipynb)
+    Introducing **[Unsloth Desktop](https://unsloth.ai/docs/desktop)**, the first desktop app to run and train models. Free and open-source for macOS, Windows and Linux. [GitHub](https://github.com/unslothai/unsloth) • [Download](https://unsloth.ai/download)
 
-    <table><tr>
-    <td align="center"><a href="https://unsloth.ai/docs/new/studio"><img src="https://unsloth.ai/docs/~gitbook/image?url=https%3A%2F%2F3215535692-files.gitbook.io%2F~%2Ffiles%2Fv0%2Fb%2Fgitbook-x-prod.appspot.com%2Fo%2Fspaces%252FxhOjnexMCB3dmuQFQ2Zq%252Fuploads%252FxV1PO5DbF3ksB51nE2Tw%252Fmore%2520cropped%2520ui%2520for%2520homepage.png%3Falt%3Dmedia%26token%3Df75942c9-3d8d-4b59-8ba2-1a4a38de1b86&width=376&dpr=3&quality=100&sign=a663c397&sv=2" width="200" height="120" alt="Unsloth Studio Training UI"></a><br><sub><b>Train models</b> — no code needed</sub></td>
-    <td align="center"><a href="https://unsloth.ai/docs/new/studio"><img src="https://unsloth.ai/docs/~gitbook/image?url=https%3A%2F%2F3215535692-files.gitbook.io%2F~%2Ffiles%2Fv0%2Fb%2Fgitbook-x-prod.appspot.com%2Fo%2Fspaces%252FxhOjnexMCB3dmuQFQ2Zq%252Fuploads%252FRCnTAZ6Uh88DIlU3g0Ij%252Fmainpage%2520unsloth.png%3Falt%3Dmedia%26token%3D837c96b6-bd09-4e81-bc76-fa50421e9bfb&width=376&dpr=3&quality=100&sign=c1a39da1&sv=2" width="200" height="120" alt="Unsloth Studio Chat UI"></a><br><sub><b>Run GGUF models</b> on Mac, Windows & Linux</sub></td>
-    </tr></table>
+    <a href="https://unsloth.ai/docs/desktop"><img src="https://raw.githubusercontent.com/unslothai/notebooks/refs/heads/main/assets/unsloth-qwen3-8.png" width="350" alt="Introducing Unsloth Desktop"></a>
 
     Train MoEs - DeepSeek, GLM, Qwen and gpt-oss 12x faster with 35% less VRAM. [Blog](https://unsloth.ai/docs/new/faster-moe)
 
@@ -446,17 +443,15 @@ def _(np, output_function):
         import_numpy()
     except Exception as e:
         print(str(e))
-    return (types,)
+    return
 
 
 @app.cell
-def _(types):
-    def create_locked_down_function(function):
-        output_function = {}
-        exec(function, {}, output_function)
-        new_matmul = output_function["matmul"]
-        new_matmul = types.FunctionType(new_matmul.__code__, {})
-        return new_matmul
+def _():
+    # Unsloth's create_locked_down_function executes the generated code with a
+    # restricted set of builtins and a restricted importer, so a reward hacking
+    # completion cannot reach os, subprocess, sockets or the filesystem.
+    from unsloth import create_locked_down_function
 
     return (create_locked_down_function,)
 

--- a/molab/gpt_oss_(20B)_GRPO_BF16.py
+++ b/molab/gpt_oss_(20B)_GRPO_BF16.py
@@ -27,7 +27,7 @@
 
 import marimo
 
-__generated_with = "0.24.0"
+__generated_with = "0.23.8"
 app = marimo.App()
 
 

--- a/nb/AMD-Gemma4_(E2B)_GRPO.ipynb
+++ b/nb/AMD-Gemma4_(E2B)_GRPO.ipynb
@@ -484,12 +484,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def create_locked_down_function(function):\n",
-    "    output_function = {}\n",
-    "    exec(function, {}, output_function)\n",
-    "    new_matmul = output_function[\"matmul\"]\n",
-    "    new_matmul = types.FunctionType(new_matmul.__code__, {})\n",
-    "    return new_matmul"
+    "# Unsloth's create_locked_down_function executes the generated code with a\n",
+    "# restricted set of builtins and a restricted importer, so a reward hacking\n",
+    "# completion cannot reach os, subprocess, sockets or the filesystem.\n",
+    "from unsloth import create_locked_down_function"
    ]
   },
   {

--- a/nb/AMD-gpt-oss-(20B)-GRPO.ipynb
+++ b/nb/AMD-gpt-oss-(20B)-GRPO.ipynb
@@ -908,12 +908,10 @@
       },
       "outputs": [],
       "source": [
-        "def create_locked_down_function(function):\n",
-        "    output_function = {}\n",
-        "    exec(function, {}, output_function)\n",
-        "    new_matmul = output_function[\"matmul\"]\n",
-        "    new_matmul = types.FunctionType(new_matmul.__code__, {})\n",
-        "    return new_matmul"
+        "# Unsloth's create_locked_down_function executes the generated code with a\n",
+        "# restricted set of builtins and a restricted importer, so a reward hacking\n",
+        "# completion cannot reach os, subprocess, sockets or the filesystem.\n",
+        "from unsloth import create_locked_down_function"
       ]
     },
     {

--- a/nb/AMD-gpt-oss-(20B)_A100-GRPO.ipynb
+++ b/nb/AMD-gpt-oss-(20B)_A100-GRPO.ipynb
@@ -908,12 +908,10 @@
    },
    "outputs": [],
    "source": [
-    "def create_locked_down_function(function):\n",
-    "    output_function = {}\n",
-    "    exec(function, {}, output_function)\n",
-    "    new_matmul = output_function[\"matmul\"]\n",
-    "    new_matmul = types.FunctionType(new_matmul.__code__, {})\n",
-    "    return new_matmul"
+    "# Unsloth's create_locked_down_function executes the generated code with a\n",
+    "# restricted set of builtins and a restricted importer, so a reward hacking\n",
+    "# completion cannot reach os, subprocess, sockets or the filesystem.\n",
+    "from unsloth import create_locked_down_function"
    ]
   },
   {

--- a/nb/AMD-gpt_oss_(20B)_GRPO_BF16.ipynb
+++ b/nb/AMD-gpt_oss_(20B)_GRPO_BF16.ipynb
@@ -1025,12 +1025,10 @@
    },
    "outputs": [],
    "source": [
-    "def create_locked_down_function(function):\n",
-    "    output_function = {}\n",
-    "    exec(function, {}, output_function)\n",
-    "    new_matmul = output_function[\"matmul\"]\n",
-    "    new_matmul = types.FunctionType(new_matmul.__code__, {})\n",
-    "    return new_matmul"
+    "# Unsloth's create_locked_down_function executes the generated code with a\n",
+    "# restricted set of builtins and a restricted importer, so a reward hacking\n",
+    "# completion cannot reach os, subprocess, sockets or the filesystem.\n",
+    "from unsloth import create_locked_down_function"
    ]
   },
   {

--- a/nb/Gemma4_(E2B)_GRPO.ipynb
+++ b/nb/Gemma4_(E2B)_GRPO.ipynb
@@ -477,12 +477,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def create_locked_down_function(function):\n",
-    "    output_function = {}\n",
-    "    exec(function, {}, output_function)\n",
-    "    new_matmul = output_function[\"matmul\"]\n",
-    "    new_matmul = types.FunctionType(new_matmul.__code__, {})\n",
-    "    return new_matmul"
+    "# Unsloth's create_locked_down_function executes the generated code with a\n",
+    "# restricted set of builtins and a restricted importer, so a reward hacking\n",
+    "# completion cannot reach os, subprocess, sockets or the filesystem.\n",
+    "from unsloth import create_locked_down_function"
    ]
   },
   {

--- a/nb/HuggingFace Course-gpt-oss-(20B)-GRPO.ipynb
+++ b/nb/HuggingFace Course-gpt-oss-(20B)-GRPO.ipynb
@@ -910,12 +910,10 @@
    },
    "outputs": [],
    "source": [
-    "def create_locked_down_function(function):\n",
-    "    output_function = {}\n",
-    "    exec(function, {}, output_function)\n",
-    "    new_matmul = output_function[\"matmul\"]\n",
-    "    new_matmul = types.FunctionType(new_matmul.__code__, {})\n",
-    "    return new_matmul"
+    "# Unsloth's create_locked_down_function executes the generated code with a\n",
+    "# restricted set of builtins and a restricted importer, so a reward hacking\n",
+    "# completion cannot reach os, subprocess, sockets or the filesystem.\n",
+    "from unsloth import create_locked_down_function"
    ]
   },
   {

--- a/nb/HuggingFace Course-gpt-oss-(20B)_A100-GRPO.ipynb
+++ b/nb/HuggingFace Course-gpt-oss-(20B)_A100-GRPO.ipynb
@@ -910,12 +910,10 @@
    },
    "outputs": [],
    "source": [
-    "def create_locked_down_function(function):\n",
-    "    output_function = {}\n",
-    "    exec(function, {}, output_function)\n",
-    "    new_matmul = output_function[\"matmul\"]\n",
-    "    new_matmul = types.FunctionType(new_matmul.__code__, {})\n",
-    "    return new_matmul"
+    "# Unsloth's create_locked_down_function executes the generated code with a\n",
+    "# restricted set of builtins and a restricted importer, so a reward hacking\n",
+    "# completion cannot reach os, subprocess, sockets or the filesystem.\n",
+    "from unsloth import create_locked_down_function"
    ]
   },
   {

--- a/nb/HuggingFace Course-gpt_oss_(20B)_GRPO_BF16.ipynb
+++ b/nb/HuggingFace Course-gpt_oss_(20B)_GRPO_BF16.ipynb
@@ -1020,12 +1020,10 @@
    },
    "outputs": [],
    "source": [
-    "def create_locked_down_function(function):\n",
-    "    output_function = {}\n",
-    "    exec(function, {}, output_function)\n",
-    "    new_matmul = output_function[\"matmul\"]\n",
-    "    new_matmul = types.FunctionType(new_matmul.__code__, {})\n",
-    "    return new_matmul"
+    "# Unsloth's create_locked_down_function executes the generated code with a\n",
+    "# restricted set of builtins and a restricted importer, so a reward hacking\n",
+    "# completion cannot reach os, subprocess, sockets or the filesystem.\n",
+    "from unsloth import create_locked_down_function"
    ]
   },
   {

--- a/nb/Kaggle-gpt-oss-(20B)-GRPO.ipynb
+++ b/nb/Kaggle-gpt-oss-(20B)-GRPO.ipynb
@@ -910,12 +910,10 @@
    },
    "outputs": [],
    "source": [
-    "def create_locked_down_function(function):\n",
-    "    output_function = {}\n",
-    "    exec(function, {}, output_function)\n",
-    "    new_matmul = output_function[\"matmul\"]\n",
-    "    new_matmul = types.FunctionType(new_matmul.__code__, {})\n",
-    "    return new_matmul"
+    "# Unsloth's create_locked_down_function executes the generated code with a\n",
+    "# restricted set of builtins and a restricted importer, so a reward hacking\n",
+    "# completion cannot reach os, subprocess, sockets or the filesystem.\n",
+    "from unsloth import create_locked_down_function"
    ]
   },
   {

--- a/nb/Kaggle-gpt-oss-(20B)_A100-GRPO.ipynb
+++ b/nb/Kaggle-gpt-oss-(20B)_A100-GRPO.ipynb
@@ -910,12 +910,10 @@
    },
    "outputs": [],
    "source": [
-    "def create_locked_down_function(function):\n",
-    "    output_function = {}\n",
-    "    exec(function, {}, output_function)\n",
-    "    new_matmul = output_function[\"matmul\"]\n",
-    "    new_matmul = types.FunctionType(new_matmul.__code__, {})\n",
-    "    return new_matmul"
+    "# Unsloth's create_locked_down_function executes the generated code with a\n",
+    "# restricted set of builtins and a restricted importer, so a reward hacking\n",
+    "# completion cannot reach os, subprocess, sockets or the filesystem.\n",
+    "from unsloth import create_locked_down_function"
    ]
   },
   {

--- a/nb/Kaggle-gpt_oss_(20B)_GRPO_BF16.ipynb
+++ b/nb/Kaggle-gpt_oss_(20B)_GRPO_BF16.ipynb
@@ -1018,12 +1018,10 @@
    },
    "outputs": [],
    "source": [
-    "def create_locked_down_function(function):\n",
-    "    output_function = {}\n",
-    "    exec(function, {}, output_function)\n",
-    "    new_matmul = output_function[\"matmul\"]\n",
-    "    new_matmul = types.FunctionType(new_matmul.__code__, {})\n",
-    "    return new_matmul"
+    "# Unsloth's create_locked_down_function executes the generated code with a\n",
+    "# restricted set of builtins and a restricted importer, so a reward hacking\n",
+    "# completion cannot reach os, subprocess, sockets or the filesystem.\n",
+    "from unsloth import create_locked_down_function"
    ]
   },
   {

--- a/nb/gpt-oss-(20B)-GRPO.ipynb
+++ b/nb/gpt-oss-(20B)-GRPO.ipynb
@@ -910,12 +910,10 @@
    },
    "outputs": [],
    "source": [
-    "def create_locked_down_function(function):\n",
-    "    output_function = {}\n",
-    "    exec(function, {}, output_function)\n",
-    "    new_matmul = output_function[\"matmul\"]\n",
-    "    new_matmul = types.FunctionType(new_matmul.__code__, {})\n",
-    "    return new_matmul"
+    "# Unsloth's create_locked_down_function executes the generated code with a\n",
+    "# restricted set of builtins and a restricted importer, so a reward hacking\n",
+    "# completion cannot reach os, subprocess, sockets or the filesystem.\n",
+    "from unsloth import create_locked_down_function"
    ]
   },
   {

--- a/nb/gpt-oss-(20B)_A100-GRPO.ipynb
+++ b/nb/gpt-oss-(20B)_A100-GRPO.ipynb
@@ -910,12 +910,10 @@
    },
    "outputs": [],
    "source": [
-    "def create_locked_down_function(function):\n",
-    "    output_function = {}\n",
-    "    exec(function, {}, output_function)\n",
-    "    new_matmul = output_function[\"matmul\"]\n",
-    "    new_matmul = types.FunctionType(new_matmul.__code__, {})\n",
-    "    return new_matmul"
+    "# Unsloth's create_locked_down_function executes the generated code with a\n",
+    "# restricted set of builtins and a restricted importer, so a reward hacking\n",
+    "# completion cannot reach os, subprocess, sockets or the filesystem.\n",
+    "from unsloth import create_locked_down_function"
    ]
   },
   {

--- a/nb/gpt_oss_(20B)_GRPO_BF16.ipynb
+++ b/nb/gpt_oss_(20B)_GRPO_BF16.ipynb
@@ -1018,12 +1018,10 @@
    },
    "outputs": [],
    "source": [
-    "def create_locked_down_function(function):\n",
-    "    output_function = {}\n",
-    "    exec(function, {}, output_function)\n",
-    "    new_matmul = output_function[\"matmul\"]\n",
-    "    new_matmul = types.FunctionType(new_matmul.__code__, {})\n",
-    "    return new_matmul"
+    "# Unsloth's create_locked_down_function executes the generated code with a\n",
+    "# restricted set of builtins and a restricted importer, so a reward hacking\n",
+    "# completion cannot reach os, subprocess, sockets or the filesystem.\n",
+    "from unsloth import create_locked_down_function"
    ]
   },
   {

--- a/original_template/gpt-oss-(20B)-GRPO.ipynb
+++ b/original_template/gpt-oss-(20B)-GRPO.ipynb
@@ -922,12 +922,10 @@
       },
       "outputs": [],
       "source": [
-        "def create_locked_down_function(function):\n",
-        "    output_function = {}\n",
-        "    exec(function, {}, output_function)\n",
-        "    new_matmul = output_function[\"matmul\"]\n",
-        "    new_matmul = types.FunctionType(new_matmul.__code__, {})\n",
-        "    return new_matmul"
+        "# Unsloth's create_locked_down_function executes the generated code with a\n",
+        "# restricted set of builtins and a restricted importer, so a reward hacking\n",
+        "# completion cannot reach os, subprocess, sockets or the filesystem.\n",
+        "from unsloth import create_locked_down_function\n"
       ]
     },
     {

--- a/original_template/gpt-oss-(20B)_A100-GRPO.ipynb
+++ b/original_template/gpt-oss-(20B)_A100-GRPO.ipynb
@@ -922,12 +922,10 @@
    },
    "outputs": [],
    "source": [
-    "def create_locked_down_function(function):\n",
-    "    output_function = {}\n",
-    "    exec(function, {}, output_function)\n",
-    "    new_matmul = output_function[\"matmul\"]\n",
-    "    new_matmul = types.FunctionType(new_matmul.__code__, {})\n",
-    "    return new_matmul"
+    "# Unsloth's create_locked_down_function executes the generated code with a\n",
+    "# restricted set of builtins and a restricted importer, so a reward hacking\n",
+    "# completion cannot reach os, subprocess, sockets or the filesystem.\n",
+    "from unsloth import create_locked_down_function\n"
    ]
   },
   {

--- a/original_template/gpt_oss_(20B)_GRPO_BF16.ipynb
+++ b/original_template/gpt_oss_(20B)_GRPO_BF16.ipynb
@@ -992,12 +992,10 @@
    },
    "outputs": [],
    "source": [
-    "def create_locked_down_function(function):\n",
-    "    output_function = {}\n",
-    "    exec(function, {}, output_function)\n",
-    "    new_matmul = output_function[\"matmul\"]\n",
-    "    new_matmul = types.FunctionType(new_matmul.__code__, {})\n",
-    "    return new_matmul"
+    "# Unsloth's create_locked_down_function executes the generated code with a\n",
+    "# restricted set of builtins and a restricted importer, so a reward hacking\n",
+    "# completion cannot reach os, subprocess, sockets or the filesystem.\n",
+    "from unsloth import create_locked_down_function\n"
    ]
   },
   {

--- a/python_scripts/AMD-Gemma4_(E2B)_GRPO.py
+++ b/python_scripts/AMD-Gemma4_(E2B)_GRPO.py
@@ -321,12 +321,10 @@ except Exception as e:
 # In[ ]:
 
 
-def create_locked_down_function(function):
-    output_function = {}
-    exec(function, {}, output_function)
-    new_matmul = output_function["matmul"]
-    new_matmul = types.FunctionType(new_matmul.__code__, {})
-    return new_matmul
+# Unsloth's create_locked_down_function executes the generated code with a
+# restricted set of builtins and a restricted importer, so a reward hacking
+# completion cannot reach os, subprocess, sockets or the filesystem.
+from unsloth import create_locked_down_function
 
 
 # # Countering Reward Hacking 3: Stop caching

--- a/python_scripts/AMD-gpt-oss-(20B)-GRPO.py
+++ b/python_scripts/AMD-gpt-oss-(20B)-GRPO.py
@@ -321,12 +321,10 @@ except Exception as e:
 # In[ ]:
 
 
-def create_locked_down_function(function):
-    output_function = {}
-    exec(function, {}, output_function)
-    new_matmul = output_function["matmul"]
-    new_matmul = types.FunctionType(new_matmul.__code__, {})
-    return new_matmul
+# Unsloth's create_locked_down_function executes the generated code with a
+# restricted set of builtins and a restricted importer, so a reward hacking
+# completion cannot reach os, subprocess, sockets or the filesystem.
+from unsloth import create_locked_down_function
 
 
 # # Countering Reward Hacking 3: Stop caching

--- a/python_scripts/AMD-gpt-oss-(20B)_A100-GRPO.py
+++ b/python_scripts/AMD-gpt-oss-(20B)_A100-GRPO.py
@@ -321,12 +321,10 @@ except Exception as e:
 # In[ ]:
 
 
-def create_locked_down_function(function):
-    output_function = {}
-    exec(function, {}, output_function)
-    new_matmul = output_function["matmul"]
-    new_matmul = types.FunctionType(new_matmul.__code__, {})
-    return new_matmul
+# Unsloth's create_locked_down_function executes the generated code with a
+# restricted set of builtins and a restricted importer, so a reward hacking
+# completion cannot reach os, subprocess, sockets or the filesystem.
+from unsloth import create_locked_down_function
 
 
 # # Countering Reward Hacking 3: Stop caching

--- a/python_scripts/AMD-gpt_oss_(20B)_GRPO_BF16.py
+++ b/python_scripts/AMD-gpt_oss_(20B)_GRPO_BF16.py
@@ -321,12 +321,10 @@ except Exception as e:
 # In[ ]:
 
 
-def create_locked_down_function(function):
-    output_function = {}
-    exec(function, {}, output_function)
-    new_matmul = output_function["matmul"]
-    new_matmul = types.FunctionType(new_matmul.__code__, {})
-    return new_matmul
+# Unsloth's create_locked_down_function executes the generated code with a
+# restricted set of builtins and a restricted importer, so a reward hacking
+# completion cannot reach os, subprocess, sockets or the filesystem.
+from unsloth import create_locked_down_function
 
 
 # # Countering Reward Hacking 3: Stop caching

--- a/python_scripts/Gemma4_(E2B)_GRPO.py
+++ b/python_scripts/Gemma4_(E2B)_GRPO.py
@@ -311,12 +311,10 @@ except Exception as e:
 # In[ ]:
 
 
-def create_locked_down_function(function):
-    output_function = {}
-    exec(function, {}, output_function)
-    new_matmul = output_function["matmul"]
-    new_matmul = types.FunctionType(new_matmul.__code__, {})
-    return new_matmul
+# Unsloth's create_locked_down_function executes the generated code with a
+# restricted set of builtins and a restricted importer, so a reward hacking
+# completion cannot reach os, subprocess, sockets or the filesystem.
+from unsloth import create_locked_down_function
 
 
 # # Countering Reward Hacking 3: Stop caching

--- a/python_scripts/HuggingFace Course-gpt-oss-(20B)-GRPO.py
+++ b/python_scripts/HuggingFace Course-gpt-oss-(20B)-GRPO.py
@@ -315,12 +315,10 @@ except Exception as e:
 # In[ ]:
 
 
-def create_locked_down_function(function):
-    output_function = {}
-    exec(function, {}, output_function)
-    new_matmul = output_function["matmul"]
-    new_matmul = types.FunctionType(new_matmul.__code__, {})
-    return new_matmul
+# Unsloth's create_locked_down_function executes the generated code with a
+# restricted set of builtins and a restricted importer, so a reward hacking
+# completion cannot reach os, subprocess, sockets or the filesystem.
+from unsloth import create_locked_down_function
 
 
 # # Countering Reward Hacking 3: Stop caching

--- a/python_scripts/HuggingFace Course-gpt-oss-(20B)_A100-GRPO.py
+++ b/python_scripts/HuggingFace Course-gpt-oss-(20B)_A100-GRPO.py
@@ -315,12 +315,10 @@ except Exception as e:
 # In[ ]:
 
 
-def create_locked_down_function(function):
-    output_function = {}
-    exec(function, {}, output_function)
-    new_matmul = output_function["matmul"]
-    new_matmul = types.FunctionType(new_matmul.__code__, {})
-    return new_matmul
+# Unsloth's create_locked_down_function executes the generated code with a
+# restricted set of builtins and a restricted importer, so a reward hacking
+# completion cannot reach os, subprocess, sockets or the filesystem.
+from unsloth import create_locked_down_function
 
 
 # # Countering Reward Hacking 3: Stop caching

--- a/python_scripts/HuggingFace Course-gpt_oss_(20B)_GRPO_BF16.py
+++ b/python_scripts/HuggingFace Course-gpt_oss_(20B)_GRPO_BF16.py
@@ -315,12 +315,10 @@ except Exception as e:
 # In[ ]:
 
 
-def create_locked_down_function(function):
-    output_function = {}
-    exec(function, {}, output_function)
-    new_matmul = output_function["matmul"]
-    new_matmul = types.FunctionType(new_matmul.__code__, {})
-    return new_matmul
+# Unsloth's create_locked_down_function executes the generated code with a
+# restricted set of builtins and a restricted importer, so a reward hacking
+# completion cannot reach os, subprocess, sockets or the filesystem.
+from unsloth import create_locked_down_function
 
 
 # # Countering Reward Hacking 3: Stop caching

--- a/python_scripts/Kaggle-gpt-oss-(20B)-GRPO.py
+++ b/python_scripts/Kaggle-gpt-oss-(20B)-GRPO.py
@@ -315,12 +315,10 @@ except Exception as e:
 # In[ ]:
 
 
-def create_locked_down_function(function):
-    output_function = {}
-    exec(function, {}, output_function)
-    new_matmul = output_function["matmul"]
-    new_matmul = types.FunctionType(new_matmul.__code__, {})
-    return new_matmul
+# Unsloth's create_locked_down_function executes the generated code with a
+# restricted set of builtins and a restricted importer, so a reward hacking
+# completion cannot reach os, subprocess, sockets or the filesystem.
+from unsloth import create_locked_down_function
 
 
 # # Countering Reward Hacking 3: Stop caching

--- a/python_scripts/Kaggle-gpt-oss-(20B)_A100-GRPO.py
+++ b/python_scripts/Kaggle-gpt-oss-(20B)_A100-GRPO.py
@@ -315,12 +315,10 @@ except Exception as e:
 # In[ ]:
 
 
-def create_locked_down_function(function):
-    output_function = {}
-    exec(function, {}, output_function)
-    new_matmul = output_function["matmul"]
-    new_matmul = types.FunctionType(new_matmul.__code__, {})
-    return new_matmul
+# Unsloth's create_locked_down_function executes the generated code with a
+# restricted set of builtins and a restricted importer, so a reward hacking
+# completion cannot reach os, subprocess, sockets or the filesystem.
+from unsloth import create_locked_down_function
 
 
 # # Countering Reward Hacking 3: Stop caching

--- a/python_scripts/Kaggle-gpt_oss_(20B)_GRPO_BF16.py
+++ b/python_scripts/Kaggle-gpt_oss_(20B)_GRPO_BF16.py
@@ -313,12 +313,10 @@ except Exception as e:
 # In[ ]:
 
 
-def create_locked_down_function(function):
-    output_function = {}
-    exec(function, {}, output_function)
-    new_matmul = output_function["matmul"]
-    new_matmul = types.FunctionType(new_matmul.__code__, {})
-    return new_matmul
+# Unsloth's create_locked_down_function executes the generated code with a
+# restricted set of builtins and a restricted importer, so a reward hacking
+# completion cannot reach os, subprocess, sockets or the filesystem.
+from unsloth import create_locked_down_function
 
 
 # # Countering Reward Hacking 3: Stop caching

--- a/python_scripts/gpt-oss-(20B)-GRPO.py
+++ b/python_scripts/gpt-oss-(20B)-GRPO.py
@@ -315,12 +315,10 @@ except Exception as e:
 # In[ ]:
 
 
-def create_locked_down_function(function):
-    output_function = {}
-    exec(function, {}, output_function)
-    new_matmul = output_function["matmul"]
-    new_matmul = types.FunctionType(new_matmul.__code__, {})
-    return new_matmul
+# Unsloth's create_locked_down_function executes the generated code with a
+# restricted set of builtins and a restricted importer, so a reward hacking
+# completion cannot reach os, subprocess, sockets or the filesystem.
+from unsloth import create_locked_down_function
 
 
 # # Countering Reward Hacking 3: Stop caching

--- a/python_scripts/gpt-oss-(20B)_A100-GRPO.py
+++ b/python_scripts/gpt-oss-(20B)_A100-GRPO.py
@@ -315,12 +315,10 @@ except Exception as e:
 # In[ ]:
 
 
-def create_locked_down_function(function):
-    output_function = {}
-    exec(function, {}, output_function)
-    new_matmul = output_function["matmul"]
-    new_matmul = types.FunctionType(new_matmul.__code__, {})
-    return new_matmul
+# Unsloth's create_locked_down_function executes the generated code with a
+# restricted set of builtins and a restricted importer, so a reward hacking
+# completion cannot reach os, subprocess, sockets or the filesystem.
+from unsloth import create_locked_down_function
 
 
 # # Countering Reward Hacking 3: Stop caching

--- a/python_scripts/gpt_oss_(20B)_GRPO_BF16.py
+++ b/python_scripts/gpt_oss_(20B)_GRPO_BF16.py
@@ -313,12 +313,10 @@ except Exception as e:
 # In[ ]:
 
 
-def create_locked_down_function(function):
-    output_function = {}
-    exec(function, {}, output_function)
-    new_matmul = output_function["matmul"]
-    new_matmul = types.FunctionType(new_matmul.__code__, {})
-    return new_matmul
+# Unsloth's create_locked_down_function executes the generated code with a
+# restricted set of builtins and a restricted importer, so a reward hacking
+# completion cannot reach os, subprocess, sockets or the filesystem.
+from unsloth import create_locked_down_function
 
 
 # # Countering Reward Hacking 3: Stop caching


### PR DESCRIPTION
Companion to unslothai/unsloth-zoo#1105.

The 2048 and Sudoku RL notebooks already pull the sandbox helper from the library:

```python
from unsloth import check_python_modules, create_locked_down_function
```

The gpt-oss and Gemma4 matmul GRPO family does not. It still carries its own inline copy:

```python
def create_locked_down_function(function):
    output_function = {}
    exec(function, {}, output_function)
    new_matmul = output_function["matmul"]
    new_matmul = types.FunctionType(new_matmul.__code__, {})
    return new_matmul
```

That copy executes the model's generated Python with full builtins available. The `types.FunctionType(..., {})` line reads as if it locks things down, but CPython injects the real builtins module into any globals mapping that has no `__builtins__` key, so it does not. `check_only_stdlib_imports` does not cover the gap either: `os`, `subprocess` and `socket` are all stdlib and pass it, and the `ok` flag it returns is computed and then discarded by the reward functions, which only test `if function is None or "error" in info`.

So a completion of this shape runs on the user's Colab or Kaggle box:

```python
def matmul(A, B):
    import os
    os.system("...")
```

The cell had spread to 35 files by copy paste. This PR switches the four sources of truth over to the library helper and regenerates the rest, so every one of them picks up the hardening in unslothai/unsloth-zoo#1105.

## Sources of truth edited

- `original_template/gpt-oss-(20B)-GRPO.ipynb`
- `original_template/gpt-oss-(20B)_A100-GRPO.ipynb`
- `original_template/gpt_oss_(20B)_GRPO_BF16.ipynb`
- `nb/Gemma4_(E2B)_GRPO.ipynb`, which has no `original_template` counterpart and is therefore its own source

The other 31 files in the diff are regenerated output from `update_all_notebooks.py` and `update_all_notebooks.py --amd`.

## What is deliberately left alone

`check_only_stdlib_imports` and the explanation around it stay exactly as they are. They still drive the `no_cheating` reward, which is what they were written for, and the teaching narrative about reward hacking is unchanged. The demo cells that `exec` a hardcoded `sample` string are also untouched, since that is a literal rather than model output.

No user facing change: same cells, same flow, same outputs.

## Verification

- Repo wide grep for `exec(function` returns nothing.
- `tests/test_python_scripts_regen_parity.py` passes 888/888.
- Sandbox behaviour is covered on the unsloth-zoo side. Escapes via `import os`, `__import__`, `open`, `eval`, `getattr` and `().__class__.__bases__[0].__subclasses__()` are blocked, while the 2048 sample using `import math` and `from typing import Callable`, the matmul sample from this notebook, and the Sudoku sample all still run.

## One note for whoever regenerates next

The molab step fails silently when `marimo` is not installed. It prints a warning and the generator still exits 0, which leaves the four molab files stale while the run looks like it succeeded. I only caught it by grepping for the old cell afterwards. Might be worth making that step fail loudly.

A full regeneration also produces a fair amount of drift unrelated to any given change: a marimo version bump, the announcement cell switching from Studio to Desktop, README rows for notebooks missing from the table, `scripts/model_created_at.csv`, and a handful of AMD and molab variants that had never been generated. I reverted all of that here to keep this diff to the security fix. The four molab files are the exception, since marimo rewrites whole files and the version bump cannot be separated out.
