### PR TITLE
Run test_desktop_banner.py in CI, and catch the reverse drift too

### DIFF
--- a/.github/workflows/notebooks-tests-ci.yml
+++ b/.github/workflows/notebooks-tests-ci.yml
@@ -146,6 +146,13 @@ jobs:
         run: |
           python -m pytest tests/test_amd_news_section.py -q --tb=short
 
+      - name: tests/test_desktop_banner.py
+        # The Desktop promo is rewritten into every News section by the
+        # generator, so a partial regen leaves some notebooks on the old Studio
+        # copy.
+        run: |
+          python -m pytest tests/test_desktop_banner.py -q --tb=short
+
       - name: tests/test_amd_moe_autotune_guard.py
         run: |
           python -m pytest tests/test_amd_moe_autotune_guard.py -q --tb=short

--- a/tests/test_every_test_runs_in_ci.py
+++ b/tests/test_every_test_runs_in_ci.py
@@ -231,6 +231,21 @@ def test_a_url_fragment_is_not_read_as_a_comment():
     assert any("subdirectory=y" in c for c in _shell_commands(block))
 
 
+@pytest.mark.parametrize(
+    "name", sorted(_named_in_workflow()), ids=lambda n: n)
+def test_every_ci_step_names_a_test_that_exists(name):
+    """The other direction: a step outliving the file it ran.
+
+    A rename or delete that misses the workflow leaves a step invoking a path
+    that is gone. pytest exits 4 on that, which reads as a broken workflow
+    rather than the missing coverage it actually is, so name it here.
+    """
+    assert (TESTS / name).is_file(), (
+        f"notebooks-tests-ci.yml runs tests/{name}, which does not exist. "
+        f"Drop the step, or restore the file."
+    )
+
+
 def test_the_real_workflow_still_reports_its_pytest_files():
     """A fold or split that stopped matching would leave the gate asserting
     against an empty set."""


### PR DESCRIPTION
`tests/test_desktop_banner.py` has never run. It was added in #363 without a step in `notebooks-tests-ci.yml`, and `tests/test_every_test_runs_in_ci.py` has been failing on `main` ever since, which is why `notebook static checks (HARD GATE)` is red on every open PR.

## Which is wrong, the gate or the test

Both are correct, so the missing step is the fix. Worth writing down why, since the opposite conclusion was available:

**The gate is right.** The workflow deliberately names each test file in its own step rather than discovering `tests/`, so a new file runs nowhere until someone adds a step. That is exactly what happened. The gate reads the `run:` commands rather than the file text, and carries its own unit tests for the ways a step can look like coverage without being it: an `echo` that mentions pytest, a `pip install pytest`, a comment naming a file beside a real call, a `name:` left behind after its command was replaced.

**The test is right too, and it passes:** 1376 assertions across every notebook, checking the Desktop promo the generator writes into each News section. A partial regen leaves some notebooks on the old Studio copy, which is a real thing to catch. It is worth running, not deleting.

So #363 was incomplete rather than wrong.

## Why it reached main

The gate caught it on #363 itself. That PR merged with `notebook static checks (HARD GATE)` already at `failure`.

Nothing enforces it: `main` has no `required_status_checks` key in its branch protection at all, so despite the name, the HARD GATE job is advisory. `enforce_admins` is also `false`.

That is a repo setting rather than a code change, so this PR does not touch it, but it is the actual reason a red gate does not stop a merge. Worth deciding on separately.

## Robustification

The gate only checked one direction, that every test file is named by a step. The reverse drift was unguarded: a step outliving the file it ran, after a rename or a delete. That surfaces as pytest exiting 4, which reads as a broken workflow rather than as the missing coverage it is.

`test_every_ci_step_names_a_test_that_exists` now names it directly. Verified against a synthetic workflow whose only step runs a deleted test. No dangling steps exist today (42 named, 43 on disk, the one difference being the file this PR wires up), so it lands green and guards from here.

## Verification

- `tests/test_every_test_runs_in_ci.py` + `tests/test_desktop_banner.py`: 1478 passed
- `tests/test_every_test_runs_in_ci.py` alone: 102 passed, up from 58, the difference being the new per-step parametrisation
- Workflow still parses; jobs unchanged (`notebook-lint`, `api-drift`, `security-tests`)
- `ruff check` clean
